### PR TITLE
Added spinner for High Dimension Data

### DIFF
--- a/web-app/js/datasetExplorer/highDimensionData.js
+++ b/web-app/js/datasetExplorer/highDimensionData.js
@@ -24,17 +24,22 @@
  * @param divId
  */
 function gatherHighDimensionalData(divId){
+	var spinnerMask = new Ext.LoadMask(Ext.getBody(), {msg:"Please wait..."});
+	spinnerMask.show();
+	
 	if(!variableDivEmpty(divId)
 			&& ((GLOBAL.CurrentSubsetIDs[1]	== null) ||	(multipleSubsets() && GLOBAL.CurrentSubsetIDs[2]== null))){
 		runAllQueriesForSubsetId(function(){gatherHighDimensionalData(divId);}, divId);
 		return;
 	}
 	if(variableDivEmpty(divId)){
+		spinnerMask.hide();
 		Ext.Msg.alert("No cohort selected!", "Please select a cohort first.");
 		return;
 	}
 	//genePatternReplacement();
 	//Send a request to generate the heatmapdata that we use to populate the dropdowns in the popup.
+	
 	Ext.Ajax.request(
 			{
 				url : pageInfo.basePath+"/analysis/heatmapvalidate",
@@ -49,11 +54,13 @@ function gatherHighDimensionalData(divId){
 				),
 				success : function(result, request)
 				{
+					spinnerMask.hide();
 					determineHighDimVariableType(result);
 					readCohortData(result,divId);
 				},
 				failure : function(result, request)
 				{
+					spinnerMask.hide();
 					determineHighDimVariableType(result);
 					readCohortData(result,divId);
 				}
@@ -62,16 +69,22 @@ function gatherHighDimensionalData(divId){
 }
 
 function gatherHighDimensionalDataSingleSubset(divId, currentSubsetId){
+	var spinnerMask = new Ext.LoadMask(Ext.getBody(), {msg:"Please wait..."});
+	spinnerMask.show();
+	
 	if((!variableDivEmpty(divId) && currentSubsetId== null)){
+		spinnerMask.hide();
 		runQueryForSubsetidSingleSubset(function(sId){gatherHighDimensionalDataSingleSubset(divId, sId);}, divId);
 		return;
 	}
 	if(variableDivEmpty(divId)){
+		spinnerMask.hide();
 		Ext.Msg.alert("No cohort selected!", "Please select a cohort first.");
 		return;
 	}
 	//genePatternReplacement();
 	//Send a request to generate the heatmapdata that we use to populate the dropdowns in the popup.
+	
 	Ext.Ajax.request(
 			{
 				url : pageInfo.basePath+"/analysis/heatmapvalidate",
@@ -86,11 +99,13 @@ function gatherHighDimensionalDataSingleSubset(divId, currentSubsetId){
 				),
 				success : function(result, request)
 				{
+					spinnerMask.hide();
 					determineHighDimVariableType(result);
 					readCohortData(result,divId);
 				},
 				failure : function(result, request)
 				{
+					spinnerMask.hide();
 					determineHighDimVariableType(result);
 					readCohortData(result,divId);
 				}
@@ -516,7 +531,7 @@ function toggleDataAssociationFields(extEle){
 	}
 	
 	//display the appropriate submit button
-	if(GLOBAL.Analysis=="dataAssociation"){
+	if(GLOBAL.Analysis=="dataAssociation" || GLOBAL.Analysis=='MetaCoreEnrichment'){
 		document.getElementById("compareStepPathwaySelectionOKButton").style.display="none";
 		document.getElementById("dataAssociationApplyButton").style.display="";
 	}else if(GLOBAL.Analysis=='Advanced'){


### PR DESCRIPTION
Since High Dimension Data button in analysis invokes a series of AJAX calls that are time consuming, added a standard progress status / spinner popup. Was tested on our intensively-used instance for the past 3 weeks, no issues found.
