### PR TITLE
Fix incompatibility with inline Rmodules plugin setup introduced by latest changes

### DIFF
--- a/application.properties
+++ b/application.properties
@@ -1,5 +1,2 @@
 app.grails.version=2.2.0
 app.name=transmart
-app.servlet.version=2.4
-app.version=
-plugins.rdc-rmodules=0.2

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -22,7 +22,7 @@ grails.project.class.dir = "target/classes"
 grails.project.test.class.dir = "target/test-classes"
 grails.project.test.reports.dir = "target/test-reports"
 
-grails.plugin.location.rmodules = "../Rmodules"
+//grails.plugin.location.'rdc-modules' = "../Rmodules"
 
 //grails.project.war.file = "target/${appName}-${appVersion}.war"
 grails.project.dependency.resolution = {


### PR DESCRIPTION
A great way to develop concurrently on transmartApp as well as on Rmodules is to enable Rmodules as an inline plugin rather than pulling it in as a plugin dependency.
This setup was broken by a commit introducing rdc-rmodules in a deprecated way in application.properties. This patch will fix that and re-enable this setup again, while leaving the default at just pulling in rdc-rmodules as a plugin dependency.
(trying to be verbose to support community uptake :-))
