### PR TITLE
Corrected org.springframework.security dependency error (missing 3.2.0)

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -43,6 +43,10 @@ grails.project.dependency.resolution = {
                 name: 'eTRIKS Reporitory',
                 root: 'http://repo.etriks.org/content/groups/public/',
         ])
+                mavenRepo([
+                name: 'Spring IO Reporitory',
+                root: 'http://repo.spring.io/milestone/'
+        ])
     }
     dependencies {
 		runtime 'postgresql:postgresql:9.1-901.jdbc4'


### PR DESCRIPTION
Error caused by spring-security 3.2.0 dependency on sprint-security-core:2.0 (From Peter Rice) See http://grails.1312388.n4.nabble.com/Spring-Security-2-0-RC-release-td4649905.html
