### PR TITLE
Replace parameter name for Solr path for Browse (TMART-312)

### DIFF
--- a/grails-app/services/transmartapp/SolrFacetService.groovy
+++ b/grails-app/services/transmartapp/SolrFacetService.groovy
@@ -610,7 +610,7 @@ class SolrFacetService {
 
         String solrScheme = Holders.config.com.rwg.solr.scheme
         String solrHost = Holders.config.com.rwg.solr.host
-        String solrPath = Holders.config.com.rwg.solr.path
+        String solrPath = Holders.config.com.rwg.solr.browse.path
         String solrRequestUrl = new URI(solrScheme, solrHost, solrPath, "", "").toURL()
 
         return solrRequestUrl


### PR DESCRIPTION
There is a conflict between Solr paths for Browse and GWAS that are got from the same parameter
