### PR TITLE
Fix http-builder dependency

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -44,7 +44,7 @@ grails.project.dependency.resolution = {
         compile "org.apache.lucene:lucene-highlighter:2.4.0"
         compile 'commons-net:commons-net:3.3' // used for ftp transfers
         compile 'org.apache.commons:commons-math:2.2' //>2MB lib briefly used in ChartController
-        compile 'org.codehaus.groovy:http-builder:0.4.1', {
+        compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.5.1', {
             excludes 'groovy', 'nekohtml'
         }
         compile 'org.grails:grails-plugin-rest:2.3.5-hyve4'


### PR DESCRIPTION
In c49be4d2ffa2d5aa6b3f6155b19a69485fd43a10 accidentally (I thought) dependency to http-builder-0.5.1 was replaced with 0.4.1 (you can see removed lib/http-builder-0.5.1.jar). It brokes some http requests working previously (i.e. request with array parameter).
In http-builder 0.4.1:
[id: Arrays.asList(1, 2, 3)] produces id=[1, 2, 3]
In http-builder 0.5.1:
[id: Arrays.asList(1, 2, 3)] produces id=1&id=2&id=3
This commit reverts http-builder dependency to original state.
