### PR TITLE
Plugin (dependency) for transmart-rest-api to 1.2.2-SNAPSHOT

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -143,7 +143,7 @@ grails.project.dependency.resolution = {
             //compile ':transmart-java:1.2.2-SNAPSHOT'
             runtime ':dalliance-plugin:0.2-SNAPSHOT'
             runtime ':transmart-mydas:0.1-SNAPSHOT'
-            runtime ':transmart-rest-api:0.1-SNAPSHOT'
+            runtime ':transmart-rest-api:1.2.2-SNAPSHOT'
             runtime ':blend4j-plugin:1.2.2-SNAPSHOT'
             runtime ':transmart-metacore-plugin:1.2.2-SNAPSHOT'
 


### PR DESCRIPTION
Changed version of plugin (dependency) for transmart-rest-api to 1.2.2-SNAPSHOT; this is version currently being build by the master branch of the rest-api.
