### PR TITLE
Lock account temp-y after some failed login trials

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -198,6 +198,13 @@ org.transmart.security.spnegoEnabled = false
 // Bear in mind bug GRAILS-11376 with Tomcat NIO and Grails 2.3.6+
 grails.plugins.sendfile.tomcat = false
 
+grails.plugin.springsecurity.useSecurityEventListener = true
+
+bruteForceLoginLock {
+    allowedNumberOfAttempts = 3
+    lockTimeInMinutes = 10
+}
+
 log4j = {
     environments {
         test {

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -18,6 +18,9 @@ import org.transmart.marshallers.MarshallerRegistrarService
 import org.transmart.spring.QuartzSpringScope
 import org.transmartproject.core.users.User
 import org.transmartproject.export.HighDimExporter
+import org.transmartproject.security.AuthSuccessEventListener
+import org.transmartproject.security.BadCredentialsEventListener
+import org.transmartproject.security.BruteForceLoginLockService
 
 def logger = Logger.getLogger('com.recomdata.conf.resources')
 
@@ -113,4 +116,18 @@ beans = {
             return {}
         }
     }
+
+    bruteForceLoginLockService(BruteForceLoginLockService) {
+        allowedNumberOfAttempts = grailsApplication.config.bruteForceLoginLock.allowedNumberOfAttempts
+        lockTimeInMinutes = grailsApplication.config.bruteForceLoginLock.lockTimeInMinutes
+    }
+
+    authSuccessEventListener(AuthSuccessEventListener) {
+        bruteForceLoginLockService = ref('bruteForceLoginLockService')
+    }
+
+    badCredentialsEventListener(BadCredentialsEventListener) {
+        bruteForceLoginLockService = ref('bruteForceLoginLockService')
+    }
+
 }

--- a/grails-app/services/com/recomdata/security/AuthUserDetailsService.groovy
+++ b/grails-app/services/com/recomdata/security/AuthUserDetailsService.groovy
@@ -26,6 +26,8 @@ class AuthUserDetailsService implements GrailsUserDetailsService {
        autoinjection into services */
     @Resource
     def grailsApplication
+    @Resource
+    def bruteForceLoginLockService
 
     def conf = SpringSecurityUtils.securityConfig
 
@@ -94,7 +96,7 @@ class AuthUserDetailsService implements GrailsUserDetailsService {
         }
 
         new AuthUserDetails(user.username, user.passwd, user.enabled,
-                !user.accountExpired, !user.passwordExpired, !user.accountLocked,
+                true, true, !bruteForceLoginLockService.isLocked(user.username),
                 authorities ?: NO_ROLES, user.id, user.userRealName)
     }
 }

--- a/grails-app/services/org/transmartproject/security/BruteForceLoginLockService.groovy
+++ b/grails-app/services/org/transmartproject/security/BruteForceLoginLockService.groovy
@@ -1,0 +1,77 @@
+package org.transmartproject.security
+
+import com.google.common.cache.Cache
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import org.springframework.util.Assert
+
+import javax.annotation.PostConstruct
+import java.util.concurrent.TimeUnit
+
+/**
+ * This class counts failed login attempts per account.
+ * It has functionality for checking when given account should be locked and on how long.
+ *
+ * idea taken from
+ * http://www.grygoriy.com/blog/2012/10/06/prevent-brute-force-attack-with-spring-security/
+ */
+class BruteForceLoginLockService {
+
+    private Cache failedAttempts
+
+    int allowedNumberOfAttempts
+
+    int lockTimeInMinutes
+
+    @PostConstruct
+    void init() {
+        Assert.isTrue(allowedNumberOfAttempts > 0, 'allowedNumberOfAttempts has to be greater than 0')
+        Assert.isTrue(lockTimeInMinutes > 0, 'lockTimeInMinutes has to be greater than 0')
+
+        failedAttempts = CacheBuilder.newBuilder()
+                .expireAfterWrite(lockTimeInMinutes, TimeUnit.MINUTES)
+                .build({ 0 } as CacheLoader)
+    }
+
+    /**
+     * Triggers on each unsuccessful login attempt and increases number of failedAttempts in local accumulator
+     * @param login - username which is trying to login
+     * @return
+     */
+    def failLogin(String login) {
+        def numberOfAttempts = failedAttempts.get(login)
+        log.debug "fail login ${login} previous number for failedAttempts $numberOfAttempts"
+        failedAttempts.put(login, numberOfAttempts + 1)
+    }
+
+    /**
+     * Triggers on each successful login attempt and resets number of failedAttempts in local accumulator
+     * @param login - username which is login
+     */
+    def loginSuccess(String login) {
+        if (!isLocked(login)) {
+            log.debug "successfull login for ${login}"
+            failedAttempts.invalidate(login)
+        }
+    }
+
+    /**
+     * Check weather account is locked.
+     * @param login
+     * @return
+     */
+    boolean isLocked(String login) {
+        remainedAttempts(login) <= 0
+    }
+
+    /**
+     * Remained attempts
+     * @param login
+     * @return
+     */
+    int remainedAttempts(String login) {
+        int result = allowedNumberOfAttempts - failedAttempts.get(login)
+        result < 0 ? 0 : result
+    }
+
+}

--- a/src/groovy/com/recomdata/security/LdapAuthUserDetailsMapper.groovy
+++ b/src/groovy/com/recomdata/security/LdapAuthUserDetailsMapper.groovy
@@ -25,6 +25,7 @@ public class LdapAuthUserDetailsMapper implements UserDetailsContextMapper {
     def dataSource
     def springSecurityService
     def databasePortabilityService
+    def loginAttemptCacheService
     def conf = SpringSecurityUtils.securityConfig
 
     private final Log logger = LogFactory.getLog(LdapAuthUserDetailsMapper.class);
@@ -115,7 +116,16 @@ public class LdapAuthUserDetailsMapper implements UserDetailsContextMapper {
             } else
                 authority = authorities
 
-            return new AuthUserDetails(user.username, user.passwd, user.enabled, !user.accountExpired, !user.passwordExpired, !user.accountLocked, authority ?: AuthUserDetailsService.NO_ROLES, user.id, "LDAP '" + user.userRealName + "'")
+            return new AuthUserDetails(
+                    user.username,
+                    user.passwd,
+                    user.enabled,
+                    true,
+                    true,
+                    !loginAttemptCacheService.isLocked(user.username),
+                    authority ?: AuthUserDetailsService.NO_ROLES,
+                    user.id,
+                    "LDAP '${user.userRealName}'")
         }
     }
 

--- a/src/groovy/org/transmartproject/security/AuthSuccessEventListener.groovy
+++ b/src/groovy/org/transmartproject/security/AuthSuccessEventListener.groovy
@@ -1,0 +1,14 @@
+package org.transmartproject.security
+
+import org.springframework.context.ApplicationListener
+import org.springframework.security.authentication.event.AuthenticationSuccessEvent
+
+class AuthSuccessEventListener implements ApplicationListener<AuthenticationSuccessEvent> {
+
+    BruteForceLoginLockService bruteForceLoginLockService
+
+    @Override
+    void onApplicationEvent(AuthenticationSuccessEvent event) {
+        bruteForceLoginLockService.loginSuccess(event.authentication.name)
+    }
+}

--- a/src/groovy/org/transmartproject/security/BadCredentialsEventListener.groovy
+++ b/src/groovy/org/transmartproject/security/BadCredentialsEventListener.groovy
@@ -1,0 +1,22 @@
+package org.transmartproject.security
+
+import org.springframework.context.ApplicationListener
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent
+import org.springframework.security.authentication.event.AuthenticationFailureBadCredentialsEvent
+import org.springframework.security.authentication.event.AuthenticationFailureServiceExceptionEvent
+
+class BadCredentialsEventListener implements ApplicationListener<AbstractAuthenticationFailureEvent> {
+
+    BruteForceLoginLockService bruteForceLoginLockService
+
+    void onApplicationEvent(AbstractAuthenticationFailureEvent event) {
+        //We have to check for AuthenticationFailureServiceExceptionEvent because of bug in current version of OAuth provider
+        //see https://github.com/spring-projects/spring-security-oauth/pull/383
+        if ([AuthenticationFailureBadCredentialsEvent, AuthenticationFailureServiceExceptionEvent].any {
+            it.isAssignableFrom(event.class)
+        }) {
+            bruteForceLoginLockService.failLogin(event.authentication.name)
+        }
+    }
+
+}

--- a/test/unit/org/transmartproject/security/BruteForceLoginLockServiceTests.groovy
+++ b/test/unit/org/transmartproject/security/BruteForceLoginLockServiceTests.groovy
@@ -1,0 +1,69 @@
+package org.transmartproject.security
+
+import com.google.common.cache.CacheBuilder
+import com.google.common.cache.CacheLoader
+import grails.test.GrailsUnitTestCase
+
+import java.util.concurrent.TimeUnit
+
+class BruteForceLoginLockServiceTests extends GrailsUnitTestCase {
+
+    BruteForceLoginLockService service
+
+    void setUp() {
+        super.setUp()
+        service = new BruteForceLoginLockService(allowedNumberOfAttempts: 2, lockTimeInMinutes: 10)
+        service.init()
+    }
+
+    void testLockAfterAllowedNumberOfAttempts() {
+        assertFalse(service.isLocked('test'))
+        service.failLogin('test')
+        assertFalse(service.isLocked('test'))
+        service.failLogin('test')
+        assertTrue(service.isLocked('test'))
+    }
+
+    void testSuccessfulTrialDoesNotUnlock() {
+        service.allowedNumberOfAttempts = 1
+
+        service.failLogin('test')
+        assertTrue(service.isLocked('test'))
+        service.loginSuccess('test')
+        assertTrue(service.isLocked('test'))
+    }
+
+    void testSuccessfulTrialRemovesBadTrialsCount() {
+        assertEquals(2, service.remainedAttempts('test'))
+        service.failLogin('test')
+        assertEquals(1, service.remainedAttempts('test'))
+        service.loginSuccess('test')
+        assertEquals(2, service.remainedAttempts('test'))
+    }
+
+    void testTimeRemovesBadTrialsCount() {
+        service.allowedNumberOfAttempts = 1
+        //0 - expires immediately
+        service.@failedAttempts = CacheBuilder.newBuilder()
+                .expireAfterWrite(0, TimeUnit.MINUTES)
+                .build({ 0 } as CacheLoader)
+
+        service.failLogin('test')
+        assertFalse(service.isLocked('test'))
+    }
+
+    void testInvalidAllowedNumberOfAttemptsSetting() {
+        service.allowedNumberOfAttempts = -1
+        shouldFail(IllegalArgumentException, {
+            service.init()
+        })
+    }
+
+    void testInvalidLockTimeInMinutesSetting() {
+        service.lockTimeInMinutes = -1
+        shouldFail(IllegalArgumentException, {
+            service.init()
+        })
+    }
+
+}


### PR DESCRIPTION
Restrict brute-force login attempts. After X failed
trials an account gets locked for Y minutes.

X - brutforce.loginAttempts.allowedNumberOfAttempts (default 3)
Y - brutforce.loginAttempts.lockTimeInMinutes (default 10)