### PR TITLE
Fix undesired resizing effects in gui for acgh analyses.

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -1059,10 +1059,6 @@ function onWindowResize() {
         var exportPanelTop = jQuery('#dataTypesGridPanel .x-panel-body').offset()['top'];
         jQuery('#dataTypesGridPanel .x-panel-body').height(jQuery(window).height() - exportPanelTop - 40);
     }
-    if (jQuery('#dataAssociationPanel .x-panel-body').size() > 0) {
-        var panelTop = jQuery('#dataAssociationPanel .x-panel-body').offset()['top'];
-        jQuery('#dataAssociationPanel .x-panel-body').height(jQuery(window).height() - panelTop);
-    }
     if (jQuery('#resultsTabPanel .x-tab-panel-body').size() > 0) {
         var panelTop = jQuery('#resultsTabPanel .x-tab-panel-body').offset()['top'];
         jQuery('#resultsTabPanel .x-tab-panel-body').height(jQuery(window).height() - panelTop);


### PR DESCRIPTION
The resizing of the dataAssociationPanel somehow triggers resizing of the gui in the acgh analyses. It would be ok if this was the correct size, but it is not.