### PR TITLE
Remove access details first before removing group

### DIFF
--- a/grails-app/controllers/UserGroupController.groovy
+++ b/grails-app/controllers/UserGroupController.groovy
@@ -4,6 +4,7 @@ import grails.validation.ValidationException
 import org.transmart.searchapp.AccessLog
 import org.transmart.searchapp.AuthUser
 import org.transmart.searchapp.Principal
+import org.transmart.searchapp.SecureObjectAccess
 import org.transmart.searchapp.UserGroup
 
 class UserGroupController {
@@ -42,6 +43,8 @@ class UserGroupController {
     def delete = {
         def userGroupInstance = UserGroup.get(params.id)
         if (userGroupInstance) {
+            def accessList = SecureObjectAccess.findByPrincipal(userGroupInstance)
+            accessList.each { it.delete(flush: true) }
             userGroupInstance.delete()
             flash.message = "UserGroup ${params.id} deleted"
             redirect(action: "list")


### PR DESCRIPTION
Steps to reproduce error:
 - Create a new group
 - Go to 'Access Control by Group'
 - Search for the group in the autosuggest text field
 - Add a study to it from available studies
 - Go to the 'Group List'
 - Select the group and delete it
Expected: Group should be deleted
Actual: Error occurs ("An error has occurred"),
though group seems to be deleted from group list,
but is still available in 'access control by group'.