### PR TITLE
Embed URL in HTML Link

### DIFF
--- a/grails-app/services/I2b2HelperService.groovy
+++ b/grails-app/services/I2b2HelperService.groovy
@@ -24,6 +24,8 @@ import javax.xml.xpath.XPathFactory
 import java.sql.ResultSet
 import java.sql.SQLException
 import java.sql.Statement
+import java.net.URL;
+import java.net.MalformedURLException;
 
 import static org.transmart.authorization.QueriesResourceAuthorizationDecorator.checkQueryResultAccess
 
@@ -732,6 +734,24 @@ class I2b2HelperService {
     }
 
     /**
+     * Checks if a string represents a URL
+     */
+    def Boolean isURL( String s ) {
+
+        Boolean isurl;
+
+        // Attempt to convert string into an URL.   
+        try {
+            URL url = new URL(s);
+            isurl = true;
+        } catch (MalformedURLException e) {
+            isurl = false
+        }
+
+        return isurl;
+    }
+
+    /**
      * Adds a column of data to the grid export table
      */
     def ExportTableNew addConceptDataToTable(ExportTableNew tablein, String concept_key, String result_instance_id) {
@@ -791,6 +811,10 @@ class I2b2HelperService {
                     String value = row.TVAL_CHAR
                     if (value == null) {
                         value = "Y";
+                    }
+                    if (isURL(value)) {
+                        /* Embed URL in a HTML Link */
+                        value = "<a href=\"" + value + "\" target=\"_blank\">" + value + "</a>";
                     }
                     if (tablein.containsRow(subject)) /*should contain all subjects already if I ran the demographics first*/ {
                         tablein.getRow(subject).put(columnid, value.toString());
@@ -866,6 +890,10 @@ class I2b2HelperService {
                 String value = row[1]
                 if (value == null) {
                     value = "Y";
+                }
+                if (isURL(value)) {
+                    /* Embed URL in a HTML Link */
+                    value = "<a href=\"" + value + "\" target=\"_blank\">" + value + "</a>"
                 }
                 if (tablein.containsRow(subject)) /*should contain all subjects already if I ran the demographics first*/ {
                     tablein.getRow(subject).put(columnid, value.toString());


### PR DESCRIPTION
@fguitton @forus @timdo @pandis83 

This pull request concerns a Grid View visualization proposal to embed a (non-numeric) observation, in case it represents a URL, in a HTML Link format. This would allow a tranSMART user to click on those Grid View cells and follow the hyperlink (which e.g. is a reference to image data of a patient or raw molecular data from a sample of a patient).
No specific assumptions are made about the observations nor the observations' concepts. Every observation which is a well formed URL, is embedded in a HTML Link.
A use case for this feature would be: A prostate cancer study collects both clinical data of the patients as well as MR images of the patient's prostate. The MR images are stored in an image archive and read by radiologists who score the lesions encountered in those images with respect to specific characteristics (e.g. PI-RADS). All these observations (clinical, prostate MRI characteristics and also the references to the MRI's in the image archive) are mapped on tranSMART concepts and uploaded to tranSMART. Analysis of these data might reveal some unexpected or suspicious observations for some of the patients. Via the Grid View tab, tranSMART users can inspect the images in the image archive which are the source for those suspicious image characteristics.