### PR TITLE
Across trial nodes should never be locked

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -1664,6 +1664,10 @@ function createTree(ontresponse) {
         if ((access != undefined && access != 'Locked') || GLOBAL.IsAdmin) {
             lockedNode = false;
         }
+        if (lockedNode && key.indexOf('\\\\xtrials\\') === 0) {
+            // across trial nodes should never be locked
+            lockedNode = false;
+        }
 
         if (GLOBAL.PathToExpand.indexOf(key) > -1 && GLOBAL.UniqueLeaves.indexOf(key + ",") == -1 && !lockedNode) {
             autoExpand = true;

--- a/web-app/js/datasetExplorer/ext-i2b2.js
+++ b/web-app/js/datasetExplorer/ext-i2b2.js
@@ -129,7 +129,9 @@ var mobj=result;
             child.setText(child.text + " (" + count + ")");
         }
 
-        if ((access != undefined && access != 'Locked') || GLOBAL.IsAdmin) //if im an admin or there is an access level other than locked leave node unlocked
+        if ((access != undefined && access != 'Locked') ||
+                key.indexOf('\\\\xtrials\\') === 0 || // across trials node should never be locked
+                GLOBAL.IsAdmin) //if im an admin or there is an access level other than locked leave node unlocked
         {
             //leave node unlocked must have some read access
         }


### PR DESCRIPTION
Implemented in the client code because the server-side code is rather
convoluteid and this is all feel-good stuff anyway. Currently there are
no server-side enforced checks on the tree traversal, only in other
areas such as cohort building and anaylisis running.