### PR TITLE
display message that password must be provided only if no password is en...

### DIFF
--- a/grails-app/controllers/AuthUserController.groovy
+++ b/grails-app/controllers/AuthUserController.groovy
@@ -122,7 +122,7 @@ class AuthUserController {
             return render(view: create ? 'create' : 'edit', model: buildPersonModel(person))
         }
 
-        if (params.passwd && !params.passwd.isEmpty() && !params.passwd.equals(person.getPersistentValue("passwd"))) {
+        if (params.passwd && !params.passwd.isEmpty()) {
 
             def passwordStrength = grailsApplication.config.com.recomdata.passwordstrength ?: null
             def strengthPattern = passwordStrength?.pattern ?: null
@@ -135,7 +135,7 @@ class AuthUserController {
             }
 
             person.passwd = springSecurityService.encodePassword(params.passwd)
-        } else  {
+        } else if (create) {
             flash.message = 'Password must be provided';
             return render(view: create ? 'create' : 'edit', model: buildPersonModel(person))
         }


### PR DESCRIPTION
...tered when creating a user account. Not when updating

@fguitton 
Issue FT-1310 (https://jira.ctmmtrait.nl/browse/FT-1310) describes an undesired behavior in tranSMART when disabling/enabling user accounts. If an update of the user information is done and no password has been entered in the form, a flash message appears on the screen with the text "Password must be provided". This message should not appear when doing an update (only when creating an account). Moreover, the update of the user information is done successfully.
The modifications in this pull request are such that the flash message will only appear when no password is provided during creation of a user account.
In the same section of the code, the condition for doing a password strength check has been adapted. This condition test consisted of a test whether the provided password for a user was different compared to the password known by the system. Both passwords will always differ, as the password stored by the system is an encoded password. This part of the condition test has been removed.
