### PR TITLE
Improve naming/placing of the exported HD files

### DIFF
--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -6,6 +6,7 @@ import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
 import org.transmartproject.core.dataquery.highdim.assayconstraints.AssayConstraint
 import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.core.ontology.OntologyTerm
 import org.transmartproject.export.HighDimExporter
 
 class HighDimExportService {
@@ -13,6 +14,7 @@ class HighDimExportService {
     def highDimensionResourceService
     def highDimExporterRegistry
     def queriesResourceService
+    def conceptsResourceService
 
     // FIXME: jobResultsService lives in Rmodules, so this is probably not a dependency we should have here
     def jobResultsService
@@ -35,21 +37,24 @@ class HighDimExportService {
         }
 
         def fileNames = []
+
         HighDimensionDataTypeResource dataTypeResource = highDimensionResourceService.getSubResourceForType(args.dataType)
-        if (!conceptKeys) {
+        def ontologyTerms
+        if (conceptKeys) {
+            ontologyTerms = conceptKeys.collectAll { conceptsResourceService.getByKey it }
+        } else {
             def queryResult = queriesResourceService.getQueryResultFromId(resultInstanceId)
-            def ontologyTerms = dataTypeResource.getAllOntologyTermsForDataTypeBy(queryResult)
-            conceptKeys = ontologyTerms.collect { it.key }
+            ontologyTerms = dataTypeResource.getAllOntologyTermsForDataTypeBy(queryResult)
         }
-        conceptKeys.eachWithIndex { String conceptPath, int index ->
+
+        ontologyTerms.each { OntologyTerm term ->
             // Add constraints to filter the output
             List<File> files = exportForSingleNode(
-                    conceptPath,
+                    term,
                     resultInstanceId,
                     args.studyDir,
                     args.format,
                     args.dataType,
-                    index,
                     args.jobName)
 
             fileNames.addAll(files*.absolutePath)
@@ -58,7 +63,9 @@ class HighDimExportService {
         fileNames
     }
 
-    private List<File> exportForSingleNode(String conceptPath, Long resultInstanceId, File studyDir, String format, String dataType, Integer index, String jobName) {
+    List<File> exportForSingleNode(OntologyTerm term, Long resultInstanceId, File studyDir, String format, String dataType, String jobName) {
+
+        List<File> outputFiles = []
 
         HighDimensionDataTypeResource dataTypeResource = highDimensionResourceService.getSubResourceForType(dataType)
 
@@ -70,7 +77,7 @@ class HighDimExportService {
 
         assayConstraints << dataTypeResource.createAssayConstraint(
                 AssayConstraint.ONTOLOGY_TERM_CONSTRAINT,
-                concept_key: conceptPath)
+                concept_key: term.key)
 
         // Setup class to export the data
         HighDimExporter exporter = highDimExporterRegistry.getExporterForFormat(format)
@@ -80,20 +87,18 @@ class HighDimExportService {
         TabularResult<AssayColumn, DataRow> tabularResult =
                 dataTypeResource.retrieveData(assayConstraints, [], projection)
 
-        List<File> outputFiles = []
-
         try {
             exporter.export(
                     tabularResult,
                     projection,
-                    { String fileName ->
-                        //TODO Imrove naming for parent folder
-                        File parentFolder = new File(studyDir, "${dataType}_${makeFileNameFromConceptPath(conceptPath)}_${index}")
-                        parentFolder.mkdirs()
-                        File outputFile = new File(parentFolder, fileName)
+                    { String dataFileName, String dataFileExt ->
+                        File nodeDataFolder = new File(studyDir, getRelativeFolderPathForSingleNode(term))
+                        File outputFile = new File(nodeDataFolder,
+                                "${dataFileName}_${dataType}.${dataFileExt.toLowerCase()}")
                         if (outputFile.exists()) {
                             throw new RuntimeException("${outputFile} file already exists.")
                         }
+                        nodeDataFolder.mkdirs()
                         outputFiles << outputFile
                         outputFile.newOutputStream()
                     },
@@ -103,16 +108,24 @@ class HighDimExportService {
         } finally {
             tabularResult.close()
         }
-
         outputFiles
     }
 
-    private String makeFileNameFromConceptPath(String conceptPath) {
-        conceptPath
-                .split('\\\\')
-                .reverse()[0..1]
-                .join('_')
-                .replaceAll('[\\W_]+', '_')
+    static String getRelativeFolderPathForSingleNode(OntologyTerm term) {
+        def leafConceptFullName = term.fullName
+        String resultConceptPath = leafConceptFullName
+        def study = term.study
+        if (study) {
+            def studyConceptFullName = study.ontologyTerm.fullName
+            //use internal study folders only
+            resultConceptPath = leafConceptFullName.replace(studyConceptFullName, '')
+        }
+
+        resultConceptPath.split('\\\\').findAll().collect { String folderName ->
+            //Reversible way to encode a string to use as filename
+            //http://stackoverflow.com/questions/1184176/how-can-i-safely-encode-a-string-in-java-to-use-as-a-filename
+            URLEncoder.encode(folderName, 'UTF-8')
+        }.join(File.separator)
     }
 
     def boolean jobIsCancelled(jobName) {

--- a/src/groovy/org/transmartproject/export/AcghBedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/AcghBedExporter.groovy
@@ -118,7 +118,7 @@ class AcghBedExporter implements HighDimExporter {
                     if (writer == null) {
                         writer = new BufferedWriter(
                                     new OutputStreamWriter(
-                                            newOutputStream("${assay.sampleCode}_${assay.id}.${format.toLowerCase()}"), 'UTF-8'))
+                                            newOutputStream("${assay.sampleCode}_${assay.id}", format), 'UTF-8'))
                         writer << "track name=\"${assay.sampleCode}\" itemRgb=\"On\" genome_build=\"${datarow.platform.genomeReleaseId}\"\n"
                         streamsPerSample[assay.id] = writer
                     }

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -79,7 +79,7 @@ class TabSeparatedExporter implements HighDimExporter {
             [it.key, getFieldTranslation(it.key).toUpperCase()]
         }
 
-        newOutputStream("data.${format.toLowerCase()}").withWriter("UTF-8") { writer ->
+        newOutputStream("data", format).withWriter("UTF-8") { writer ->
 
             // First write the header
             writeLine(writer, createHeader(dataKeys.values() + rowKeys.values()))

--- a/src/groovy/org/transmartproject/export/VCFExporter.groovy
+++ b/src/groovy/org/transmartproject/export/VCFExporter.groovy
@@ -74,7 +74,7 @@ class VCFExporter implements HighDimExporter {
             return
         }
 
-        newOutputStream("data.${format.toLowerCase()}").withWriter("UTF-8") { writer ->
+        newOutputStream("data", format).withWriter("UTF-8") { writer ->
 
             // Write the headers
             headers.each {

--- a/test/integration/org/transmart/dataexport/HighDimExportServiceTests.groovy
+++ b/test/integration/org/transmart/dataexport/HighDimExportServiceTests.groovy
@@ -67,7 +67,7 @@ class HighDimExportServiceTests {
 
         assertThat files, allOf (
                 hasSize(1),
-                contains(endsWith('mrna_foo_i2b2_main_0/data.tsv')))
+                contains(endsWith('/foo/data_mrna.tsv')))
         def file = new File(files[0])
         assertTrue(file.exists())
         assertThat file.length(), greaterThan(0l)
@@ -84,7 +84,7 @@ class HighDimExportServiceTests {
 
         assertThat files, allOf (
                 hasSize(1),
-                contains(endsWith('mrna_foo_i2b2_main_0/data.tsv')))
+                contains(endsWith('/foo/data_mrna.tsv')))
         def file = new File(files[0])
         assertTrue(file.exists())
         assertThat file.length(), greaterThan(0l)

--- a/test/unit/org/transmart/dataexport/HighDimExportServiceUnitTests.groovy
+++ b/test/unit/org/transmart/dataexport/HighDimExportServiceUnitTests.groovy
@@ -1,0 +1,75 @@
+package org.transmart.dataexport
+
+import com.recomdata.transmart.data.export.HighDimExportService
+import org.gmock.WithGMock
+import org.junit.Test
+import org.transmartproject.core.ontology.OntologyTerm
+import org.transmartproject.core.ontology.Study
+
+import java.util.regex.Pattern
+
+import static org.hamcrest.MatcherAssert.assertThat
+import static org.hamcrest.Matchers.*
+import static org.junit.Assert.assertFalse
+import static org.junit.Assert.assertTrue
+
+@WithGMock
+class HighDimExportServiceUnitTests {
+
+    HighDimExportService testee = new HighDimExportService()
+
+    String forbiddenFileNameSymbols = '\"/[]:;|=,'
+
+    @Test
+    void testRelativeFolderPathForAcrossStudyNode() {
+        String testFullName = "\\Clinical Information\\${forbiddenFileNameSymbols}\\"
+
+        String relativePath = testee.getRelativeFolderPathForSingleNode([
+                getFullName: { testFullName },
+                getStudy   : { null },
+        ] as OntologyTerm)
+
+        def matcher = relativePath =~ "Clinical(.)Information${Pattern.quote(File.separator)}(.+)"
+        assertTrue relativePath, matcher.matches()
+
+        assertFalse forbiddenFileNameSymbols.contains(matcher[0][1])
+
+        String encodedFolderName = matcher[0][2]
+        assertThat encodedFolderName, not(isEmptyOrNullString())
+
+        Set forbiddenSymbolsFound = (encodedFolderName as List).intersect(forbiddenFileNameSymbols as List)
+        assertThat "Forbidden symbols ${forbiddenSymbolsFound} are found in folder name: ${relativePath}",
+                forbiddenSymbolsFound, hasSize(0)
+    }
+
+    @Test
+    void testRelativeFolderPathForTheNodeInsideStudy() {
+        String studyFolder = '\\Test Studies\\Study-1\\'
+        String testFullName = "${studyFolder}Sub Folder\\${forbiddenFileNameSymbols}\\"
+
+        String relativePath = testee.getRelativeFolderPathForSingleNode([
+                getFullName: { testFullName },
+                getStudy   : {
+                    [
+                            getOntologyTerm : {
+                                [
+                                        getFullName: { studyFolder }
+                                ] as OntologyTerm
+                            }
+                    ] as Study
+                },
+        ] as OntologyTerm)
+
+        def matcher = relativePath =~ "Sub(.)Folder${Pattern.quote(File.separator)}(.+)"
+        assertTrue relativePath, matcher.matches()
+
+        assertFalse forbiddenFileNameSymbols.contains(matcher[0][1])
+
+        String encodedFolderName = matcher[0][2]
+        assertThat encodedFolderName, not(isEmptyOrNullString())
+
+        Set forbiddenSymbolsFound = (encodedFolderName as List).intersect(forbiddenFileNameSymbols as List)
+        assertThat "Forbidden symbols ${forbiddenSymbolsFound} are found in folder name: ${relativePath}",
+                forbiddenSymbolsFound, hasSize(0)
+    }
+}

--- a/test/unit/org/transmartproject/export/AcghBedExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/AcghBedExporterTests.groovy
@@ -42,7 +42,7 @@ class AcghBedExporterTests {
         List<ByteArrayOutputStream> outputStreams = []
 
         play {
-            exporter.export(tabularResult, projection, { name ->
+            exporter.export(tabularResult, projection, { name, ext ->
                 outputStreams << new ByteArrayOutputStream()
                 outputStreams[-1]
             })
@@ -92,7 +92,7 @@ class AcghBedExporterTests {
         List<ByteArrayOutputStream> outputStreams = []
 
         play {
-            exporter.export(tabularResult, projection, { name ->
+            exporter.export(tabularResult, projection, { name, ext ->
                 outputStreams << new ByteArrayOutputStream()
                 outputStreams[-1]
             })

--- a/test/unit/org/transmartproject/export/TabSeparatedExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/TabSeparatedExporterTests.groovy
@@ -77,7 +77,7 @@ class TabSeparatedExporterTests {
 
         play {
 
-            exporter.export(tabularResult, projection, { name -> outputStream}, { true })
+            exporter.export(tabularResult, projection, { name, ext -> outputStream}, { true })
 
             // As the export is cancelled, 
             assert !outputStream.toString()
@@ -103,7 +103,7 @@ class TabSeparatedExporterTests {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
 
         play {
-            exporter.export(tabularResult, projection, { name -> outputStream })
+            exporter.export(tabularResult, projection, { name, ext -> outputStream })
 
             // Assert we have at least some text, in UTF-8 encoding
             String output = outputStream.toString("UTF-8")

--- a/test/unit/org/transmartproject/export/VCFExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/VCFExporterTests.groovy
@@ -47,7 +47,7 @@ class VCFExporterTests {
 
         play {
 
-            exporter.export(tabularResult, projection, { name -> outputStream}, { true })
+            exporter.export(tabularResult, projection, { name, ext -> outputStream}, { true })
 
             // As the export is cancelled, 
             assert !outputStream.toString()
@@ -64,7 +64,7 @@ class VCFExporterTests {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
 
         play {
-            exporter.export(tabularResult, projection, { name -> outputStream })
+            exporter.export(tabularResult, projection, { name, ext -> outputStream })
 
             // Assert we have at least some text, in UTF-8 encoding
             String output = outputStream.toString("UTF-8")
@@ -112,7 +112,7 @@ class VCFExporterTests {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
 
         play {
-            exporter.export(tabularResult, projection, { name -> outputStream })
+            exporter.export(tabularResult, projection, { name, ext -> outputStream })
 
             // Assert we have at least some text, in UTF-8 encoding
             String output = outputStream.toString("UTF-8")


### PR DESCRIPTION
- Place the data file under the folder which path resemble
the path of the exported node
- Add data type to just before extension:
    e.g. data_mrna.tsv