### PR TITLE
Gene Signature creation: bug fix for null pointer exception 

### DIFF
--- a/grails-app/controllers/GeneSignatureController.groovy
+++ b/grails-app/controllers/GeneSignatureController.groovy
@@ -795,7 +795,7 @@ class GeneSignatureController {
 
             case 2:
                 // 'other' concept code item
-                def otherConceptItem = ConceptCode.get(1)
+                def otherConceptItem = ConceptCode.get(169686)
 
                 // sources
                 wizard.sources = ConceptCode.findAllByCodeTypeName(SOURCE_CATEGORY, [sort: "bioConceptCode"])
@@ -832,19 +832,22 @@ class GeneSignatureController {
 
             case 3:
                 // 'other' concept code item
-                def otherConceptItem = ConceptCode.get(1)
+                def otherConceptItem = ConceptCode.get(169686)
 
                 // normalization methods
                 wizard.normMethods = ConceptCode.findAllByCodeTypeName(NORM_METHOD_CATEGORY, [sort: "bioConceptCode"])
-                wizard.normMethods.add(otherConceptItem);
+                if (otherConceptItem != null)
+                    wizard.normMethods.add(otherConceptItem);
 
                 // analytic categories
                 wizard.analyticTypes = ConceptCode.findAllByCodeTypeName(ANALYTIC_TYPE_CATEGORY, [sort: "bioConceptCode"])
-                wizard.analyticTypes.add(otherConceptItem)
+                if (otherConceptItem != null)
+                    wizard.analyticTypes.add(otherConceptItem)
 
                 // analysis methods
                 wizard.analysisMethods = ConceptCode.findAllByCodeTypeName(ANALYSIS_METHOD_CATEGORY, [sort: "bioConceptCode"])
-                wizard.analysisMethods.add(otherConceptItem);
+                if (otherConceptItem != null)
+                    wizard.analysisMethods.add(otherConceptItem);
 
                 // file schemas
                 wizard.schemas = GeneSignatureFileSchema.findAllBySupported(true, [sort: "name"])

--- a/grails-app/controllers/GeneSignatureController.groovy
+++ b/grails-app/controllers/GeneSignatureController.groovy
@@ -795,7 +795,8 @@ class GeneSignatureController {
 
             case 2:
                 // 'other' concept code item
-                def otherConceptItem = ConceptCode.get(169686)
+                def otherConceptCodeQuery = ConceptCode.where { codeTypeName == "OTHER" && bioConceptCode == "OTHER" }
+                def otherConceptItem = otherConceptCodeQuery.get()
 
                 // sources
                 wizard.sources = ConceptCode.findAllByCodeTypeName(SOURCE_CATEGORY, [sort: "bioConceptCode"])
@@ -832,7 +833,8 @@ class GeneSignatureController {
 
             case 3:
                 // 'other' concept code item
-                def otherConceptItem = ConceptCode.get(169686)
+                def otherConceptCodeQuery = ConceptCode.where { codeTypeName == "OTHER" && bioConceptCode == "OTHER" }
+                def otherConceptItem = otherConceptCodeQuery.get()
 
                 // normalization methods
                 wizard.normMethods = ConceptCode.findAllByCodeTypeName(NORM_METHOD_CATEGORY, [sort: "bioConceptCode"])


### PR DESCRIPTION
@ricepeterm 

This bug fix addresses the following JIRA issue: https://jira.ctmmtrait.nl/browse/FT-1378 .

An update (in transmart-data) of the content of the database table biomart.bio_concept_code introduced an new "id" (169686) for a concept code record which previously had "id" (1), to resolve a "uid for other:other clashed" problem.
The updated GeneSignatureController.groovy in this pull request, takes these changes into account and introduces also extra tests for "not null" before adding these concept items to a list.