### PR TITLE
Fix typo in function call …

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -574,7 +574,7 @@ Ext.onReady(function () {
                     runAllQueries(_activateAdvancedWorkflow, p);
                 }
 
-                activateAdvancedWorkflow();
+                _activateAdvancedWorkflow();
             },
             'afterLayout': {
                 fn: function (el) {


### PR DESCRIPTION
introduced in c29b869a97a53da335ec801ba2bd949bb27dc191

Caused error in retrieving previously run analyses.