### PR TITLE
Add WARN logging for ConfigurationHelper

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -214,6 +214,8 @@ log4j = {
             }
         }
     }
+
+    warn 'org.codehaus.groovy.grails.commons.cfg.ConfigurationHelper'
 }
 
 grails {


### PR DESCRIPTION
If any error occurs while loading external configuration files is silently fails because Transmart default configuration logs only errors, but ConfigurationHelper logs errors for external configuration files at WARN level. With this minor fix its greatly simplifies error detection in external configuration files.