### PR TITLE
Fix race condition in jobs

### DIFF
--- a/grails-app/services/com/recomdata/transmart/asynchronous/job/AsyncJobService.groovy
+++ b/grails-app/services/com/recomdata/transmart/asynchronous/job/AsyncJobService.groovy
@@ -1,10 +1,12 @@
 package com.recomdata.transmart.asynchronous.job
 
 import com.recomdata.transmart.domain.i2b2.AsyncJob
+import grails.transaction.Transactional
 import groovy.json.JsonSlurper
 import org.apache.commons.lang.StringUtils
 import org.json.JSONArray
 import org.json.JSONObject
+import org.springframework.transaction.annotation.Propagation
 import org.transmartproject.core.users.User
 
 class AsyncJobService {
@@ -150,6 +152,7 @@ class AsyncJobService {
         return result;
     }
 
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     def updateJobInputs(final String jobName, final Map params) {
         assert jobName
         assert params
@@ -158,6 +161,7 @@ class AsyncJobService {
         assert "${jobName} job is not found.", job
 
         job.jobInputsJson = new JSONObject(params).toString()
+        job.save(flush: true)
     }
 
     /**


### PR DESCRIPTION
updateStatus and updateJobInputs are called from different threads at
almost the same point, updateJobInputs from the http thread and
updateStatus from the quartz thread (and later also from another http
thread as a response to checkstatus calls from the client, but this is
not relevant).

If the updateJobInputs transaction results are not visible on the
transaction on the quartz thread at the point where the quartz thread
issues the SELECT statement that precedes the UPDATE statement, then the
Hibernate session running on the quartz thread will cache stale data for
the input params column and will include this value in all the updates
thenceforth.

This fix moves the update in the http thread (done in Rmodules) and
commits the transaction before the quartz thread code is run (done in
transmartApp).