### PR TITLE
Fix SNP export

### DIFF
--- a/grails-app/services/PlinkService.groovy
+++ b/grails-app/services/PlinkService.groovy
@@ -44,8 +44,7 @@ class PlinkService {
 						INNER JOIN de_subject_sample_mapping c on c.omic_patient_id=a.patient_num
 						INNER JOIN (SELECT DISTINCT patient_num FROM qt_patient_set_collection WHERE result_instance_id = ? AND patient_num IN 
 						            (SELECT patient_num FROM patient_dimension WHERE sourcesystem_cd NOT LIKE '%:S:%')) b on c.patient_id=b.patient_num
-						where rownum=1 
-						and a.platform_name is not null
+						where a.platform_name is not null
 					"""
         def row = sql.firstRow(query, [resultInstanceId])
 

--- a/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
@@ -15,17 +15,15 @@ class ExportMetadataService {
     def highDimExporterRegistry
     def queriesResourceService
 
-    def Map createJSONFileObject(fileType, dataFormat, patientsNumber) {
+    def Map createJSONFileObject(fileData, patientsNumber) {
         def file = [:]
-        if (dataFormat != null) {
-            file['dataFormat'] = dataFormat
-        }
-        if (fileType != null) {
-            file['fileType'] = fileType
-        }
         if (patientsNumber != null) {
             file['patientsNumber'] = patientsNumber
         }
+        file['dataTypeHasCounts'] = true
+        file['exporters'] = fileData.collect { [format: it.key, description: it.value] }
+        file['ontologyTermKeys'] = ''
+
         return file
     }
 
@@ -143,17 +141,14 @@ class ExportMetadataService {
             dataType['dataTypeName'] = value
             //TODO replace 2 with subsetLen
             for (i in 1..2) {
-                def files = []
                 if (key == 'SNP') {
-                    files.add(createJSONFileObject('.PED, .MAP & .CNV', 'Processed Data', finalMap["subset${i}"][key]))
-                    files.add(createJSONFileObject('.CEL', 'Raw Data', finalMap["subset${i}"][key + '_CEL']))
+                    dataType['subset' + i] = createJSONFileObject([".PED, .MAP & .CNV": "Processed Data", ".CEL": "Raw Data", ".TXT": 'Text'], finalMap["subset${i}"][key])
                 }
                 if ((null != finalMap["subset${i}"][key] && finalMap["subset${i}"][key] > 0))
                     dataTypeHasCounts = true;
 
                 dataType['subsetId' + i] = "subset" + i
                 dataType['subsetName' + i] = "Subset " + i
-                dataType['subset' + i] = files
                 dataType.isHighDimensional = true
             }
             if (dataTypeHasCounts) rows.add(dataType)

--- a/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportService.groovy
@@ -104,8 +104,11 @@ class ExportService {
 
             if (checkboxItem.dataTypeId) {
                 //Second item is the data type.
-                String currentDataType = checkboxItem.dataTypeId.trim()
-                subsetSelectedFilesMap.get(currentSubset)?.push(currentDataType)
+                String selectedFile = checkboxItem.dataTypeId.trim()
+                if (!(checkboxItem.fileType in ['.TSV', 'TSV'])) {
+                    selectedFile += checkboxItem.fileType
+                }
+                subsetSelectedFilesMap.get(currentSubset)?.push(selectedFile)
             }
         }
 

--- a/web-app/js/datasetExplorer/exportData/dataTab.js
+++ b/web-app/js/datasetExplorer/exportData/dataTab.js
@@ -352,7 +352,7 @@ DataExport.prototype.createSelectBoxHtml = function (file, subset, dataTypeId) {
     outStr += ' name="file_type" ' + (file.patientsNumber < 1 || file.exporters.length < 2 ? 'disabled' : '') +'>';
     if(file.exporters) {
         file.exporters.each(function (exporter) {
-            outStr += '<option value="{subset: ' + subset + ', dataTypeId: ' + dataTypeId + ', fileType: ' + exporter.format + '}">' + exporter.format + '</option>';
+            outStr += '<option value="{subset: ' + subset + ', dataTypeId: \'' + dataTypeId + '\', fileType: \'' + exporter.format + '\'}">' + exporter.format + '</option>';
         });
     }
     outStr += '</select><br/>';


### PR DESCRIPTION
When SNP node selected then Export page fails because export metadata format was changed. Also exporters for SNP data formats doesn't work with latest database structure. This fix requires changes in transmart-core-db (https://github.com/transmart/transmart-core-db/pull/37)