### PR TITLE
Fix pointcut definition for AD extension

### DIFF
--- a/src/groovy/com/recomdata/security/ActiveDirectoryLdapAuthenticationExtension.groovy
+++ b/src/groovy/com/recomdata/security/ActiveDirectoryLdapAuthenticationExtension.groovy
@@ -40,7 +40,7 @@ class ActiveDirectoryLdapAuthenticationExtension {
         return res
     }
 
-    @Around("execution(* org.springframework.security.ldap.authentication.ad.AbstractLdapAuthenticationProvider+.authenticate(..))")
+    @Around("execution(* org.springframework.security.ldap.authentication.AbstractLdapAuthenticationProvider+.authenticate(..))")
     def authenticate(ProceedingJoinPoint point) {
         Authentication auth = point.args[0]
         if (point.target instanceof ActiveDirectoryLdapAuthenticationProvider) {


### PR DESCRIPTION
I found error in pointcut definition for ActiveDirectoryLdapAuthenticationExtension. FQ class name incorrectly contains `ad` package.