### PR TITLE
Fix point invocation for AD extension

### DIFF
--- a/src/groovy/com/recomdata/security/ActiveDirectoryLdapAuthenticationExtension.groovy
+++ b/src/groovy/com/recomdata/security/ActiveDirectoryLdapAuthenticationExtension.groovy
@@ -51,6 +51,6 @@ class ActiveDirectoryLdapAuthenticationExtension {
                 return null;
             }
         }
-        return point.proceed([auth])
+        return point.proceed(auth)
     }
 }


### PR DESCRIPTION
Sorry for spamming you with pull requests, but I find one more bug for ActiveDirectoryLdapAuthenticationExtension.