### PR TITLE
adds "Export Patient IDs" button to Grid view tab

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -3355,6 +3355,15 @@ function storeLoaded(jsonStore, rows, paramsObject) {
                     }
                 });
                 bbar.add(exportButton);
+                var patientIDsButton = new Ext.Button ({
+                    text: 'Get patient IDs',
+                    listeners: {
+                        click: function () {
+                            grid.getPatientIDs()
+                        }
+                    }
+                });
+                bbar.add(patientIDsButton);
             }
         });
     }

--- a/web-app/js/datasetExplorer/gridView.js
+++ b/web-app/js/datasetExplorer/gridView.js
@@ -1,6 +1,24 @@
 
 Ext.override(Ext.grid.GridPanel, {
 
+    getPatientIDs: function() {
+        var ret = []
+        var cm = this.getColumnModel();
+
+        // get the whole data store
+        var contentRows = this.store.data.items;
+        // except .. when user has selected some rows in the grid
+        if (this.getSelectionModel().getSelections().length > 0) {
+            contentRows = this.getSelectionModel().getSelections();
+        }
+
+        var index = cm.getIndexById('patient')
+        for (var i = 0, l = contentRows.length; i < l; i++) {
+            ret.push(contentRows[i].data[cm.getDataIndex(index)]);
+        }
+        Ext.MessageBox.alert('Patient IDs', ret.join(", "));
+    },
+
     getExcelXml: function(includeHidden) {
         var worksheet = this.createWorksheet(includeHidden);
         var totalWidth = this.getColumnModel().getTotalWidth(includeHidden);


### PR DESCRIPTION
This button is useful for integration with cBioPortal and other tools which support analysis of data from multiple samples at once - make a cohort selection in tranSMART and drill down into the highdimensional data in a different tool

See screenshot for the button in action:

![patientidsbutton](https://cloud.githubusercontent.com/assets/5654699/10246410/4330c466-6911-11e5-9fa0-030e75829c13.PNG)
