### PR TITLE
Support extension mechanism for plugins

### DIFF
--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -1,6 +1,7 @@
 import com.google.common.collect.ImmutableMap
 import com.recomdata.security.ActiveDirectoryLdapAuthenticationExtension
 import grails.plugin.springsecurity.SpringSecurityUtils
+import com.recomdata.extensions.ExtensionsRegistry
 import org.apache.log4j.Logger
 import org.codehaus.groovy.grails.commons.spring.DefaultBeanConfiguration
 import org.springframework.beans.factory.config.CustomScopeConfigurer
@@ -185,4 +186,6 @@ beans = {
         sourceMap = grailsApplication.config.dataExport.bed.acgh.rgbColorScheme
     }
 
+    transmartExtensionsRegistry(ExtensionsRegistry) {
+    }
 }

--- a/grails-app/controllers/PluginDetectorController.groovy
+++ b/grails-app/controllers/PluginDetectorController.groovy
@@ -1,4 +1,4 @@
-import org.codehaus.groovy.grails.plugins.PluginManagerHolder
+import grails.util.Holders
 
 class PluginDetectorController {
 
@@ -8,7 +8,7 @@ class PluginDetectorController {
         def pluginName = request.getParameter("pluginName")
         def result = false
 
-        if (PluginManagerHolder.getPluginManager().hasGrailsPlugin(pluginName)) { // check if plugin is installed
+        if (Holders.pluginManager.hasGrailsPlugin(pluginName)) { // check if plugin is installed
             result = true
         }
 

--- a/grails-app/views/datasetExplorer/datasetExplorer.gsp
+++ b/grails-app/views/datasetExplorer/datasetExplorer.gsp
@@ -1,4 +1,5 @@
 <%@ page language="java" import="java.util.*" %>
+<%@ page language="java" import="grails.converters.JSON" %>
 <!DOCTYPE HTML>
 <html>
 <head>
@@ -160,7 +161,8 @@
             currentSubsetsStudy: '',
             isGridViewLoaded: false,
             galaxyEnabled: '${grailsApplication.config.com.galaxy.blend4j.galaxyEnabled}',
-            galaxyUrl: "${grailsApplication.config.com.galaxy.blend4j.galaxyURL}"
+            galaxyUrl: "${grailsApplication.config.com.galaxy.blend4j.galaxyURL}",
+            analysisTabExtensions: ${grailsApplication.mainContext.getBean('transmartExtensionsRegistry').analysisTabExtensions as JSON}
         };
         // initialize browser version variables; see http://www.quirksmode.org/js/detect.html
         BrowserDetect.init();

--- a/src/groovy/com/recomdata/extensions/ExtensionsRegistry.groovy
+++ b/src/groovy/com/recomdata/extensions/ExtensionsRegistry.groovy
@@ -1,0 +1,13 @@
+package com.recomdata.extensions
+
+/**
+ * Date: 14-Jan-16
+ * Time: 18:08
+ */
+class ExtensionsRegistry {
+    def analysisTabExtensions = []
+
+    void registerAnalysisTabExtension(Map<String, Object> config = [:], String extensionId, String resourcesUrl, String bootstrapFunction) {
+        analysisTabExtensions.add([extensionId: extensionId, resourcesUrl: resourcesUrl, bootstrapFunction: bootstrapFunction, config: config])
+    }
+}

--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -5,7 +5,7 @@ String.prototype.trim = function() {
 Ext.layout.BorderLayout.Region.prototype.getCollapsedEl = Ext.layout.BorderLayout.Region.prototype.getCollapsedEl.createSequence(function () {
     if ((this.position === 'north' || this.position === 'south') && !this.collapsedEl.titleEl) {
         this.collapsedEl.titleEl = this.collapsedEl.createChild({
-            style: 'color:#15428b;font:11px/15px tahoma,arial,verdana,sans-serif;padding:2px 5px;', 
+            style: 'color:#15428b;font:11px/15px tahoma,arial,verdana,sans-serif;padding:2px 5px;',
             cn: this.panel.title
         });
     }
@@ -185,7 +185,7 @@ Ext.onReady(function () {
                 },
                 disabled: GLOBAL.GPURL === ""
             },
-            '-',                            
+            '-',
             {
                 text: 'Principal Component Analysis',
                 // when checked has a boolean value, it is assumed to be a CheckItem
@@ -270,7 +270,7 @@ Ext.onReady(function () {
                     if (isSubsetEmpty(1) && isSubsetEmpty(2)) {
                         alert('Both dataset is empty. Please choose a valid dataset.');
                         return;
-                    
+
                     }
                     if ((GLOBAL.CurrentSubsetIDs[1] === null && !isSubsetEmpty(1)) || (GLOBAL.CurrentSubsetIDs[2] === null && !isSubsetEmpty(2))) {
                         runAllQueries(function()    {
@@ -345,7 +345,7 @@ Ext.onReady(function () {
         region: 'north',
         height: 340,
         autoScroll: true,
-        split: true,                    
+        split: true,
         autoLoad: {
             url: pageInfo.basePath+'/panels/subsetPanel.html',
             scripts: true,
@@ -531,9 +531,9 @@ Ext.onReady(function () {
                 }
             }
         },
-        collapsible: true                       
+        collapsible: true
     });
-    
+
     // ******************
     // Advanced Workflow
     // ******************
@@ -604,7 +604,7 @@ Ext.onReady(function () {
             deactivate: function() {
             }
         },
-        collapsible: true                       
+        collapsible: true
     });
 
     /**
@@ -699,18 +699,37 @@ Ext.onReady(function () {
 
     function loadPlugin(pluginName, scriptsUrl, bootstrap) {
         var def = jQuery.Deferred();
-        jQuery.post(pageInfo.basePath + "/pluginDetector/checkPlugin", {pluginName: pluginName}, function(data) {
-            if (data === 'true') {
-                loadResourcesByUrl(pageInfo.basePath + scriptsUrl, function() {
-                    bootstrap();
-                    def.resolve();
-                }).fail(def.reject);
-            } else {
-                def.reject();
-            }
-        }).fail(def.reject);
+        var loadResources = function () {
+            loadResourcesByUrl(pageInfo.basePath + scriptsUrl, function() {
+                bootstrap();
+                def.resolve();
+            }).fail(def.reject);
+        };
+        if (pluginName) {
+            jQuery.post(pageInfo.basePath + "/pluginDetector/checkPlugin", {pluginName: pluginName}, function (data) {
+                if (data === 'true') {
+                    loadResources();
+                } else {
+                    def.reject();
+                }
+            }).fail(def.reject);
+        } else {
+            loadResources();
+        }
 
         return def;
+    }
+
+    function loadAnalysisTabExtensions(currentIndex) {
+        if (currentIndex >= GLOBAL.analysisTabExtensions.length) {
+            return;
+        }
+        var tabExtension = GLOBAL.analysisTabExtensions[currentIndex];
+        loadPlugin(null, tabExtension.resourcesUrl, function () {
+            (window[tabExtension.bootstrapFunction])(resultsTabPanel, tabExtension.config);
+        }).always(function () {
+            loadAnalysisTabExtensions(currentIndex + 1);
+        });
     }
 
     // DALLIANCE
@@ -722,7 +741,11 @@ Ext.onReady(function () {
         if (GLOBAL.metacoreAnalyticsEnabled) {
             loadPlugin('transmart-metacore-plugin', "/MetacoreEnrichment/loadScripts", function () {
                 loadMetaCoreEnrichment(resultsTabPanel);
+            }).always(function () {
+                loadAnalysisTabExtensions(0);
             });
+        } else {
+            loadAnalysisTabExtensions(0);
         }
     });
 
@@ -753,8 +776,8 @@ Ext.onReady(function () {
                     var subsets = exportPanel.body.dom.childNodes;
                     if (subsets.length !== 2) {
                         alert("Must have two subsets!");
-                    } else { 
-                        showCompareStepPathwaySelection(); 
+                    } else {
+                        showCompareStepPathwaySelection();
                     }
                 }
             },
@@ -895,7 +918,7 @@ Ext.onReady(function () {
 
                         if (!isSubsetEmpty(subset)) {
                             runQuery(subset, showConceptDistributionHistogramForSubset);
-                        } else { 
+                        } else {
                             alert('Subset is empty!');
                         }
                     }
@@ -1212,7 +1235,7 @@ function loginComplete() {
     }
 
     projectDialogComplete();
-    
+
     // Login GenePattern server. The login process should be completed by the time a user starts GenePattern tasks.
     genePatternLogin();
 }
@@ -1529,7 +1552,7 @@ function createTree(ontresponse) {
             iconCls: iconCls,
             cls: tcls
         });
-        
+
         if (lockedNode) {
             ontRoot.attributes.access = 'locked';
             ontRoot.on('beforeload', function (node) {
@@ -1560,10 +1583,10 @@ function getSubCategories(ontresponse) {
             handler: function(event, toolEl, panel) {
                 D2H_ShowHelp((id_in === "navigateTermsPanel") ? "1066": "1091",helpURL,"wndExternal",CTXT_DISPLAY_FULLHELP);
             },
-            iconCls: "contextHelpBtn"  
+            iconCls: "contextHelpBtn"
         }
     ]);
-    
+
     var treeRoot = Ext.getCmp('navigateTermsPanel').getRootNode();
     for (c = treeRoot.childNodes.length - 1; c >= 0; c--) {
         treeRoot.childNodes[c].remove();
@@ -1849,7 +1872,7 @@ function showConceptInfoDialog(conceptKey, conceptid, conceptcomment) {
 
     conceptinfowin.load({
         url: pageInfo.basePath+"/ontology/showConceptDefinition",
-        params: {conceptKey: conceptKey}, // or a URL encoded string     
+        params: {conceptKey: conceptKey}, // or a URL encoded string
         discardUrl: true,
         nocache: true,
         text: "Loading...",
@@ -1913,7 +1936,7 @@ function showConceptSearchPopUp(conceptid) {
 
 function popitup(url) {
     newwindow = window.open(url, 'name', 'height=500,width=500,toolbar=yes,scrollbars=yes, resizable=yes,');
-    
+
     if (window.focus) {
         newwindow.focus();
     }
@@ -2507,13 +2530,13 @@ function outputSelected(opt) {
 /** 
  * Function to run the survival analysis asynchronously
  */
-function showSurvivalAnalysis() {   
+function showSurvivalAnalysis() {
     if ((!isSubsetEmpty(1) && GLOBAL.CurrentSubsetIDs[1] === null) || (!isSubsetEmpty(2) && GLOBAL.CurrentSubsetIDs[2] === null)) {
         runAllQueries(showSurvivalAnalysis);
         return;
     }
-    
-    Ext.Ajax.request({                      
+
+    Ext.Ajax.request({
         url: pageInfo.basePath+"/asyncJob/createnewjob",
         method: 'POST',
         success: function(result, request) {
@@ -2533,13 +2556,13 @@ function genePatternReplacement() {
 
 //Once, we get a job created by GPController, we run the survival analysis
 function RunSurvivalAnalysis(result, result_instance_id1, result_instance_id2, querySummary1, querySummary2) {
-    var jobNameInfo = Ext.util.JSON.decode(result.responseText);                     
+    var jobNameInfo = Ext.util.JSON.decode(result.responseText);
     var jobName = jobNameInfo.jobName;
 
     genePatternReplacement();
-    showJobStatusWindow(result);    
+    showJobStatusWindow(result);
     document.getElementById("gplogin").src = pageInfo.basePath + '/analysis/gplogin';   // log into GenePattern
-    Ext.Ajax.request({                       
+    Ext.Ajax.request({
         url: pageInfo.basePath+"/genePattern/runsurvivalanalysis",
         method: 'POST',
         timeout: '1800000',
@@ -2556,7 +2579,7 @@ function RunSurvivalAnalysis(result, result_instance_id1, result_instance_id2, q
 }
 
 function showSNPViewerSelection() {
-    
+
     if ((!isSubsetEmpty(1) && GLOBAL.CurrentSubsetIDs[1] === null) || (!isSubsetEmpty(2) && GLOBAL.CurrentSubsetIDs[2] === null)) {
         runAllQueries(showSNPViewerSelection);
         return;
@@ -2638,14 +2661,14 @@ function getSNPViewer() {
     if (selectedGenesEltValue && selectedGenesEltValue.length !== 0) {
         selectedGeneStr = selectedGenesEltValue;
     }
-    
+
     var geneAndIdListElt = Ext.get("selectedGenesAndIdSNPViewer");
     var geneAndIdListEltValue = geneAndIdListElt.dom.value;
     var geneAndIdListStr = "";
     if (geneAndIdListElt && geneAndIdListEltValue.length !== 0) {
         geneAndIdListStr = geneAndIdListEltValue;
     }
-    
+
     var selectedSNPsElt = Ext.get("selectedSNPs");
     var selectedSNPsEltValue = selectedSNPsElt.dom.value;
     var selectedSNPsStr = "";
@@ -2663,7 +2686,7 @@ function getSNPViewer() {
             //getSNPViewerComplete(result);
         },
         timeout: '1800000',
-        params: { 
+        params: {
             result_instance_id1: GLOBAL.CurrentSubsetIDs[1],
             result_instance_id2: GLOBAL.CurrentSubsetIDs[2],
             chroms: GLOBAL.CurrentChroms,
@@ -2672,12 +2695,12 @@ function getSNPViewer() {
             snps: selectedSNPsStr
         }
     });
-    
+
     showWorkflowStatusWindow();
 }
 
 function showIgvSelection() {
-    
+
     if ((!isSubsetEmpty(1) && GLOBAL.CurrentSubsetIDs[1] === null) || (!isSubsetEmpty(2) && GLOBAL.CurrentSubsetIDs[2] === null)) {
         runAllQueries(showIgvSelection);
         return;
@@ -2760,21 +2783,21 @@ function getIgv() {
     if (selectedGenesEltValue && selectedGenesEltValue.length !== 0) {
         selectedGeneStr = selectedGenesEltValue;
     }
-    
+
     var geneAndIdListElt = Ext.get("selectedGenesAndIdIgv");
     var geneAndIdListEltValue = geneAndIdListElt.dom.value;
     var geneAndIdListStr = "";
     if (geneAndIdListElt && geneAndIdListEltValue.length !== 0) {
         geneAndIdListStr = geneAndIdListEltValue;
     }
-    
+
     var selectedSNPsElt = Ext.get("selectedSNPsIgv");
     var selectedSNPsEltValue = selectedSNPsElt.dom.value;
     var selectedSNPsStr = "";
     if (selectedSNPsElt && selectedSNPsEltValue.length !== 0) {
         selectedSNPsStr = selectedSNPsEltValue;
     }
-    
+
     Ext.Ajax.request({
         url: pageInfo.basePath+"/analysis/showIgv",
         method: 'POST',
@@ -2785,7 +2808,7 @@ function getIgv() {
             //getSNPViewerComplete(result);
         },
         timeout: '1800000',
-        params: { 
+        params: {
             result_instance_id1: GLOBAL.CurrentSubsetIDs[1],
             result_instance_id2: GLOBAL.CurrentSubsetIDs[2],
             chroms: GLOBAL.CurrentChroms,
@@ -2794,12 +2817,12 @@ function getIgv() {
             snps: selectedSNPsStr
         }
     });
-    
+
     showWorkflowStatusWindow();
 }
 
 function showPlinkSelection() {
-    
+
     if ((!isSubsetEmpty(1) && GLOBAL.CurrentSubsetIDs[1] === null) || (!isSubsetEmpty(2) && GLOBAL.CurrentSubsetIDs[2] === null)) {
         runAllQueries(showIgvSelection);
         return;
@@ -2877,7 +2900,7 @@ function getPlink() {
 }
 
 function showGwasSelection() {
-    
+
     if ((!isSubsetEmpty(1) && GLOBAL.CurrentSubsetIDs[1] === null) || (!isSubsetEmpty(2) && GLOBAL.CurrentSubsetIDs[2] === null)) {
         runAllQueries(showGwasSelection);
         return;
@@ -2952,18 +2975,18 @@ function showGwasSelection() {
 /** 
  * Function to run the GWAS asynchronously
  */
-function showGwas() {   
+function showGwas() {
     if ((!isSubsetEmpty(1) && GLOBAL.CurrentSubsetIDs[1] === null) || (!isSubsetEmpty(2) && GLOBAL.CurrentSubsetIDs[2] === null)) {
         runAllQueries(showGwas);
         return;
     }
-    
+
     genePatternReplacement();
 }
 
 // After we get a job created by GPController, we run GWAS
 function runGwas(result, result_instance_id1, result_instance_id2, querySummary1, querySummary2) {
-    var jobNameInfo = Ext.util.JSON.decode(result.responseText);                     
+    var jobNameInfo = Ext.util.JSON.decode(result.responseText);
     var jobName = jobNameInfo.jobName;
 
     genePatternReplacement();
@@ -3009,10 +3032,10 @@ function compareSubsetsComplete(result, setname1, setname2) {
 
     var container = heatmapDisplay.body.dom;
     heatmap = new org.systemsbiology.visualization.BioHeatMap(document.getElementById('heatmapContainer'));
-    
+
     heatmap.draw(data, {
-        cellHeight: 5, 
-        cellWidth: 5, 
+        cellHeight: 5,
+        cellWidth: 5,
         fontHeight: 3
     });
 
@@ -3086,13 +3109,13 @@ function jsonToDataTable(jsontext) {
 //////////////////////////////////////////////////////////////////////////////////////////////////////
 // Once, we get a job created by GPController, we run the heatmap
 function RunHeatMap(result, setid1, setid2, pathway, datatype, analysis, resulttype, nclusters, timepoints1, timepoints2, sample1, sample2, rbmPanels1, rbmPanels2) {
-    var jobNameInfo = Ext.util.JSON.decode(result.responseText);                     
+    var jobNameInfo = Ext.util.JSON.decode(result.responseText);
     var jobName = jobNameInfo.jobName;
 
     //genePatternReplacement();
-    showJobStatusWindow(result);    
+    showJobStatusWindow(result);
     genePatternLogin();
-    Ext.Ajax.request({                       
+    Ext.Ajax.request({
         url: pageInfo.basePath+"/genePattern/runheatmap",
         method: 'POST',
         timeout: '1800000',
@@ -3121,7 +3144,7 @@ function RunHeatMap(result, setid1, setid2, pathway, datatype, analysis, resultt
 
 // This is the new popup window for Survival Analysis. 
 function showSurvivalAnalysisWindow(results) {
-    var resultWin = window.open('', 'Survival_Analysis_View_' + (new Date()).getTime(), 
+    var resultWin = window.open('', 'Survival_Analysis_View_' + (new Date()).getTime(),
         'width=600,height=800,scrollbars=yes,resizable=yes,location=no,toolbar=no,status=no,menubar=no,directories=no');
     resultWin.document.write(results);
 }
@@ -3144,12 +3167,12 @@ function showHaploViewWindow(results) {
         plain: false,
         modal: false,
         border:true,
-        maximizable:true,                               
+        maximizable:true,
         resizable: true,
         html: results
     });
 
-    win.show(viewport);                     
+    win.show(viewport);
 }
 
 function clearExportPanel() {
@@ -3435,7 +3458,7 @@ function watchForSymbol(options) {
 
 //Called to run the Haploviewer
 function getHaploview() {
-    Ext.Ajax.request({                      
+    Ext.Ajax.request({
         url: pageInfo.basePath+"/asyncJob/createnewjob",
         method: 'POST',
         success: function(result, request) {
@@ -3446,16 +3469,16 @@ function getHaploview() {
         },
         timeout: '1800000',
         params: {jobType:  "Haplo"}
-    }); 
+    });
 }
 
 function RunHaploViewer(result, result_instance_id1, result_instance_id2, genes) {
-    var jobNameInfo = Ext.util.JSON.decode(result.responseText);                     
+    var jobNameInfo = Ext.util.JSON.decode(result.responseText);
     var jobName = jobNameInfo.jobName;
 
-    showJobStatusWindow(result);    
+    showJobStatusWindow(result);
     document.getElementById("gplogin").src = pageInfo.basePath + '/analysis/gplogin';   // log into GenePattern
-    Ext.Ajax.request({                       
+    Ext.Ajax.request({
         url: pageInfo.basePath+"/genePattern/runhaploviewer",
         method: 'POST',
         timeout: '1800000',
@@ -3653,7 +3676,7 @@ function showWorkflowStatusWindow() {
     });
     //  }
     wfsWindow.show(viewport);
-    
+
     var updateStatus = function() {
         Ext.Ajax.request({
             url: pageInfo.basePath+"/asyncJob/checkWorkflowStatus",
@@ -3666,7 +3689,7 @@ function showWorkflowStatusWindow() {
             timeout: '300000'
         });
     };
-    
+
     var task = {
         run: updateStatus,
         interval: 4000 //4 second
@@ -3680,7 +3703,7 @@ function terminateWorkflow() {
         url: pageInfo.basePath+"/asyncJob/cancelJob",
         method: 'POST',
         success: function (result, request) {
-                
+
         },
         failure: function (result, request) {
         },
@@ -3689,7 +3712,7 @@ function terminateWorkflow() {
 }
 
 function workflowStatusUpdate(result) {
-    var response = eval("(" + result.responseText + ")");   
+    var response = eval("(" + result.responseText + ")");
     var inserthtml = response.statusHTML;
     var divele = Ext.fly("divwfstatus");
     if (divele !== null) {
@@ -3697,16 +3720,16 @@ function workflowStatusUpdate(result) {
     }
     var status = response.wfstatus;
     if (status === 'completed') {
-        runner.stopAll();       
+        runner.stopAll();
         if (divele !== null) {
             divele.update("");
-        }       
+        }
         if (wfsWindow !== null) {
             wfsWindow.close();
             wfsWindow =null;
-        }       
+        }
         showWorkflowResult(result);
-    } 
+    }
 }
 
 function showWorkflowResult(result) {
@@ -3732,7 +3755,7 @@ function showWorkflowResult(result) {
 }
 
 function showSnpGeneAnnotationPage(snpGeneAnnotationPage) {
-    var resultWin = window.open('', 'Snp_Gene_Annotation_' + (new Date()).getTime(), 
+    var resultWin = window.open('', 'Snp_Gene_Annotation_' + (new Date()).getTime(),
         'width=600,height=800,scrollbars=yes,resizable=yes,location=no,toolbar=no,status=no,menubar=no,directories=no');
     resultWin.document.write(snpGeneAnnotationPage);
 }
@@ -3759,12 +3782,12 @@ function saveComparison() {
 
 function saveComparisonComplete(result) {
     var mobj = result.responseText.evalJSON();
-    
+
     //If the window is already open, close it.
     if (this.saveComparisonWindow) {
         saveComparisonWindow.close();
     }
-    
+
     //Draw the window with the link to the comparison.
     saveComparisonWindow = new Ext.Window({
         id: 'saveComparisonWindow',
@@ -3784,10 +3807,10 @@ function saveComparisonComplete(result) {
         resizable: true,
         width: 200,
         html: mobj.link
-    }); 
-    
+    });
+
     //Show the window we just created.
-    saveComparisonWindow.show(viewport);    
+    saveComparisonWindow.show(viewport);
 }
 
 function ontFilterLoaded(el, success, response, options) {


### PR DESCRIPTION
The current approach is to add new tab to analysis is to hard-code piece of code in dataExplorer.js:
```javascript
loadPlugin('dalliance-plugin', "/Dalliance/loadScripts", function () {
        loadDalliance(resultsTabPanel);
    }).always(function () {
        // Keep loading order to prevent tabs shuffling
        if (GLOBAL.metacoreAnalyticsEnabled) {
            loadPlugin('transmart-metacore-plugin', "/MetacoreEnrichment/loadScripts", function () {
                loadMetaCoreEnrichment(resultsTabPanel);
            });
        }
    });
```
It is unclear and requires transmartApp codebase modification each time when we want to add new plug-in. Even more, if we need to add our custom plug-in, then we have to create fork or branch with these modifications.
I guess it is much better to add some extension points to TransmartApp and let plug-ins to register at these points. So all configuration and extension logic kept into plug-in code (*Plugin.groovy):
```groovy
def doWithApplicationContext = { ctx ->
        def config = Holders.config
        if (config.com.thomsonreuters.transmart.myPluginEnabled) {
            def extensionsRegistry = ctx.getBean('transmartExtensionsRegistry')
            extensionsRegistry.registerAnalysisTabExtension([:], "myplugin", "/MyPlugin/loadScripts", 'loadMyPluginTab')
        }
    }
```
`registerAnalysisTabExtension` accepts following parameters:
* initConfig - any set of options to be passed to `jsBootstrapFunction` function. Optional
* extensionId - extension identifier (may be used in future to interact between extensions)
* scriptsUrl - url which will be used to load extension scripts and stylesheets
* jsBootstrapFunction - javascript function name to bootstrap extension. The first parameter is `resultsTabPanel`, the second parameter is `initConfig`.