### PR TITLE
Add extension tabs support

### DIFF
--- a/grails-app/views/layouts/_commonheader.gsp
+++ b/grails-app/views/layouts/_commonheader.gsp
@@ -1,3 +1,4 @@
+<%@ page import="grails.plugin.springsecurity.SpringSecurityUtils" %>
 <g:if test="${debug}">
     <div id="search-explain" class="overlay">
         <b>Search Explainer</b>
@@ -24,50 +25,29 @@
                 </div>
             </g:if>
         </th>
+        <g:set var="extensionsRegistry" bean="transmartExtensionsRegistry"/>
         <th class="menuBar" style="text-align: left;">
             <!-- menu links -->
             <table class="menuDetail" id="menuLinks" style="width: 1px;"
                    align="right"><!-- Use minimum possible width -->
                 <tr>
                     <th width="150">&nbsp;</th>
-                    <%--See Config.groovy--%>
-                    <g:if test="${grailsApplication.config.ui.tabs.search.show}">
-                        <g:if test="${'search'==app}"><th class="menuVisited">Search</th></g:if>
-                        <g:else><th class="menuLink"><g:link controller="search">Search</g:link></th></g:else>
-                    </g:if>
+                    <g:set var="tabs" value="${extensionsRegistry.getTabs([
+                            [id: 'search', title: 'Search', controller: 'search', display: grailsApplication.config.ui.tabs.search.show],
+                            [id: 'rwg', title: 'Browse', controller: 'RWG', display: !grailsApplication.config.ui.tabs.browse.hide],
+                            [id: 'datasetExplorer', title: 'Analyze', controller: 'datasetExplorer'],
+                            [id: 'sampleexplorer', title: 'Sample Explorer', controller: 'sampleExplorer', display: !grailsApplication.config.ui.tabs.sampleExplorer.hide],
+                            [id: 'genesignature', title: 'Gene&nbsp;Signature/Lists', controller: 'geneSignature', display: !grailsApplication.config.ui.tabs.geneSignature.hide],
+                            [id: 'gwas', title: 'GWAS', controller: 'GWAS', display: !grailsApplication.config.ui.tabs.gwas.hide],
+                            [id: 'uploaddata', title: 'Upload Data', controller: 'uploadData', display: !grailsApplication.config.ui.tabs.uploadData.hide],
+                            [id: 'accesslog', title: 'Admin', controller: 'accessLog', display: SpringSecurityUtils.ifAnyGranted('ROLE_ADMIN')]
 
-                    <g:if test="${!grailsApplication.config.ui.tabs.browse.hide}">
-                        <g:if test="${'rwg' == app}"><th class="menuVisited">Browse</th></g:if>
-                        <g:else><th class="menuLink"><g:link controller="RWG">Browse</g:link></th></g:else>
-                    </g:if>
-                    <%--Analyze tab is always visible--%>
-                    <g:if test="${'datasetExplorer' == app}"><th class="menuVisited">Analyze</th></g:if>
-                    <g:else><th class="menuLink"><g:link controller="datasetExplorer">Analyze</g:link></th></g:else>
-
-                    <g:if test="${!grailsApplication.config.ui.tabs.sampleExplorer.hide}">
-                        <g:if test="${'sampleexplorer' == app}"><th class="menuVisited">Sample Explorer</th></g:if>
-                        <g:else><th class="menuLink"><g:link controller="sampleExplorer">Sample Explorer</g:link></th></g:else>
-                    </g:if>
-
-                    <g:if test="${!grailsApplication.config.ui.tabs.geneSignature.hide}">
-                        <g:if test="${'genesignature' == app}"><th class="menuVisited">Gene&nbsp;Signature/Lists</th></g:if>
-                        <g:else><th class="menuLink"><g:link controller="geneSignature">Gene&nbsp;Signature/Lists</g:link></th></g:else>
-                    </g:if>
-
-                    <g:if test="${!grailsApplication.config.ui.tabs.gwas.hide}">
-                        <g:if test="${'gwas' == app}"><th class="menuVisited">GWAS</th></g:if>
-                        <g:else><th class="menuLink"><g:link controller="GWAS">GWAS</g:link></th></g:else>
-                    </g:if>
-
-                    <g:if test="${!grailsApplication.config.ui.tabs.uploadData.hide}">
-                        <g:if test="${'uploaddata' == app}"><th class="menuVisited">Upload Data</th></g:if>
-                        <g:else><th class="menuLink"><g:link controller="uploadData">Upload Data</g:link></th></g:else>
-                    </g:if>
-
-                    <sec:ifAnyGranted roles="ROLE_ADMIN">
-                        <g:if test="${'accesslog' == app}"><th class="menuVisited">Admin</th></g:if>
-                        <g:else><th class="menuLink"><g:link controller="accessLog">Admin</g:link></th></g:else>
-                    </sec:ifAnyGranted>
+                    ])}"/>
+                    <g:each in="${tabs}" var="tab">
+                        <g:if test="${tab.get('display', true)}">
+                            <g:render template="/layouts/headertab" model="[id: tab.id, title: tab.title, controller: tab.controller, app: app]"/>
+                        </g:if>
+                    </g:each>
 
                     <tmpl:/layouts/utilitiesMenu/>
                 </tr>

--- a/grails-app/views/layouts/_headertab.gsp
+++ b/grails-app/views/layouts/_headertab.gsp
@@ -1,0 +1,2 @@
+<g:if test="${id == app}"><th class="menuVisited">${title}</th></g:if>
+<g:else><th class="menuLink"><g:link controller="${controller}">${title}</g:link></th></g:else>

--- a/src/groovy/com/recomdata/extensions/ExtensionsRegistry.groovy
+++ b/src/groovy/com/recomdata/extensions/ExtensionsRegistry.groovy
@@ -1,13 +1,60 @@
 package com.recomdata.extensions
 
+import groovy.transform.CompileStatic
+
 /**
  * Date: 14-Jan-16
  * Time: 18:08
  */
 class ExtensionsRegistry {
     def analysisTabExtensions = []
+    List<Map<String, Object>> tabs = new LinkedList<>()
+
+    ExtensionsRegistry() {
+    }
 
     void registerAnalysisTabExtension(Map<String, Object> config = [:], String extensionId, String resourcesUrl, String bootstrapFunction) {
         analysisTabExtensions.add([extensionId: extensionId, resourcesUrl: resourcesUrl, bootstrapFunction: bootstrapFunction, config: config])
+    }
+
+    void registerTab(Map<String, Object> config = [:], String id, String title, String controller) {
+        def tab = [id: id, title: title, controller: controller, insertBefore: config.insertBefore]
+        findAndInsertBefore(tabs, tab) { Map<String, Object> it -> tab.id in it.insertBefore }
+    }
+
+    @CompileStatic
+    private static <T> void findAndInsertBefore(List<T> items, T item, Closure<Boolean> closure) {
+        for (def it = items.listIterator(); it.hasNext();) {
+            if (closure(it.next())) {
+                // Step back to be before current tab and insert the tab before that
+                it.previous()
+                it.add(item)
+                return
+            }
+        }
+        items.add(item)
+    }
+
+    /**
+     * incorporateTab in existing tab list. If insertBefore option specified, then tries to found tab with specified id
+     * and insert new tab before that
+     */
+    @CompileStatic
+    private static void incorporateTab(LinkedList<Map<String, Object>> tabs, Map<String, Object> tab) {
+        def insertBefore = tab.insertBefore
+        if (insertBefore) {
+            findAndInsertBefore(tabs, tab) { Map<String, Object> it -> it.id in insertBefore }
+        } else {
+            tabs << tab
+        }
+    }
+
+    List<Map<String, Object>> getTabs(List<Map<String, Object>> defaultTabs = []) {
+        List<Map<String, Object>> result = new LinkedList<>()
+        result.addAll(defaultTabs)
+        for (def tab : tabs) {
+            incorporateTab(result, tab)
+        }
+        result
     }
 }


### PR DESCRIPTION
Other part of UI which is often a subject for extension is header tabs. I added to `ExtensionsRegistry` a new method for plug-ins: `registerTab`.

```groovy
void registerTab(Map<String, Object> config = [:], String id, String title, String controller)
```

It has 3 required arguments and optional config:
* id - tab identifier
* title - tab title
* controller - controller used to handle tab action
* config - now supports only one option: `insertBefore`, which can be either `String` or `Collection` with other tabs identifiers. It may be used for order resolving between tabs. 

For example, if we want to place "Dashboard" tab before first tab we can use following statement:
```groovy
transmartExtensionsRegistry.registerTab('dashboard', 'Dashboard', 'myDashboard', insertBefore: ['rwg', 'search'])
```