### PR TITLE
Replaced call metacore-plugin from transmart to the plugin

### DIFF
--- a/grails-app/views/datasetExplorer/datasetExplorer.gsp
+++ b/grails-app/views/datasetExplorer/datasetExplorer.gsp
@@ -152,8 +152,6 @@
             basePath: pageInfo.basePath,
             hideAcrossTrialsPanel: '${grailsApplication.config.com.recomdata.datasetExplorer.hideAcrossTrialsPanel}',
             sampleExplorerEnabled: ${!grailsApplication.config.ui.tabs.sampleExplorer.hide},
-            metacoreAnalyticsEnabled: '${grailsApplication.config.com.thomsonreuters.transmart.metacoreAnalyticsEnable}',
-            metacoreUrl: '${grailsApplication.config.com.thomsonreuters.transmart.metacoreURL}',
             AnalysisHasBeenRun: false,
             ResultSetRegionParams: {},
             currentReportCodes: [],

--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -741,10 +741,6 @@ Ext.onReady(function () {
     loadPlugin('dalliance-plugin', '/Dalliance/loadScripts', function () {
         loadDalliance(resultsTabPanel);
     }, true);
-    loadPlugin('transmart-metacore-plugin', '/MetacoreEnrichment/loadScripts', function () {
-        loadMetaCoreEnrichment(resultsTabPanel);
-    }, true);
-
     /* load the tabs registered with the extension mechanism */
     (function loadAnalysisTabExtensions() {
         GLOBAL.analysisTabExtensions.forEach(function(tabExtension) {


### PR DESCRIPTION
Removed hard code call transmart-metacore-plugin. Required dependency https://github.com/baroleg/transmart-metacore-plugin/tree/replaced_metacore_to_plugin