### PR TITLE
Hidome no-value feature + manual bounds entry fix

### DIFF
--- a/web-app/js/datasetExplorer/omicsFilter.js
+++ b/web-app/js/datasetExplorer/omicsFilter.js
@@ -88,18 +88,24 @@ function omicsFilterWindowReceived(result, request) {
 function repopulateFilterWindow() {
     if (omicsFilterRepopulateWindow == null) return;
 
-    jQuery("#highdimension-search-property").val(omicsFilterRepopulateWindow.omicsproperty.nodeValue);
-    jQuery("#highdimension-filter-selector").val(omicsFilterRepopulateWindow.omicsselector.nodeValue);
-    jQuery("#highdimension-filter-projection").val(omicsFilterRepopulateWindow.omicsprojection.nodeValue);
+    if (omicsFilterRepopulateWindow.omicsproperty != null) {
+        jQuery("#highdimension-search-property").val(omicsFilterRepopulateWindow.omicsproperty.nodeValue);
+    }
 
-    omicsAutoCompleteList = [omicsFilterRepopulateWindow.omicsselector.nodeValue];
+    if (omicsFilterRepopulateWindow.omicsprojection != null) {
+        jQuery("#highdimension-filter-projection").val(omicsFilterRepopulateWindow.omicsprojection.nodeValue);
+    }
 
-    showConceptDistributionHistogramForOmicsFilterComplete(null);
-    showConceptDistributionHistogramForOmicsFilter(getOmicsFilterParams());
+    if (omicsFilterRepopulateWindow.omicsselector != null) {
+        jQuery("#highdimension-filter-selector").val(omicsFilterRepopulateWindow.omicsselector.nodeValue);
+        omicsAutoCompleteList = [omicsFilterRepopulateWindow.omicsselector.nodeValue];
+        showConceptDistributionHistogramForOmicsFilterComplete(null);
+        showConceptDistributionHistogramForOmicsFilter(getOmicsFilterParams());
+    }
 }
 
 function repopulateOmicsFilterRange() {
-    if (omicsFilterRepopulateWindow == null) return;
+    if (omicsFilterRepopulateWindow.omicsvalue == null) return;
 
     if (omics_filter_info.filter_type == "SINGLE_NUMERIC" || omics_filter_info.filter_type == "ACGH") {
         var minbox = jQuery("#highdimension-amount-min");
@@ -220,45 +226,55 @@ function addOmicsFilterMinMaxInputHandlers() {
     minbox.blur(function(event) {
         var slider = jQuery("#highdimension-range");
         var value = minbox.val();
+        var sliderMin = parseFloat(slider.slider('option','min'));
+        var sliderMax = parseFloat(slider.slider('option','max'));
         if (!jQuery.isNumeric(value)) {
-            minbox.val(slider.slider('option','min'));
+            minbox.val(sliderMin);
         }
-        else if (value < slider.slider('option','min')) {
-            minbox.val(slider.slider('option','min'));
+        if (!jQuery.isNumeric(maxbox.val())) {
+            maxbox.val(sliderMax);
         }
-        else if (value > maxbox.val()) {
-            minbox.val(maxbox.val());
+        value = parseFloat(minbox.val());
+        var maxboxVal = parseFloat(maxbox.val());
+        if (value < sliderMin) {
+            minbox.val(sliderMin);
+        }
+        else if (value > maxboxVal) {
+            minbox.val(maxboxVal);
         }
 
-        slider.slider('values',0,minbox.val());
-        jQuery("#highdimension-filter-subjectcount").html(omicsFilterValues.filter(function (el, idx, array) {return el >= minbox.val();})
-            .filter(function(el, idx, array) {return el <= maxbox.val();})
+        slider.slider('values',0,value);
+        jQuery("#highdimension-filter-subjectcount").html(omicsFilterValues.filter(function (el, idx, array) {return el >= value;})
+            .filter(function(el, idx, array) {return el <= maxboxVal;})
             .length);
-        var min = slider.slider('option', 'min');
-        var max = slider.slider('option', 'max');
-        omicsSliderLowHandleRatio = (minbox.val() - min) / (max - min);
+        omicsSliderLowHandleRatio = (value - sliderMin) / (sliderMax - sliderMin);
     });
 
     maxbox.blur(function(event) {
         var slider = jQuery("#highdimension-range");
         var value = maxbox.val();
+        var sliderMin = parseFloat(slider.slider('option','min'));
+        var sliderMax = parseFloat(slider.slider('option','max'));
         if (!jQuery.isNumeric(value)) {
-            maxbox.val(slider.slider('option','max'));
+            maxbox.val(sliderMax);
         }
-        else if (value > slider.slider('option','max')) {
-            maxbox.val(slider.slider('option','max'));
+        if (!jQuery.isNumeric(minbox.val())) {
+            minbox.val(sliderMin);
         }
-        else if (value < minbox.val()) {
-            maxbox.val(minbox.val());
+        value = parseFloat(maxbox.val());
+        var minboxVal = parseFloat(minbox.val())
+        if (value > sliderMax) {
+            maxbox.val(sliderMax);
+        }
+        else if (value < minboxVal) {
+            maxbox.val(minboxVal);
         }
 
-        slider.slider('values',1,maxbox.val());
-        jQuery("#highdimension-filter-subjectcount").html(omicsFilterValues.filter(function (el, idx, array) {return el >= minbox.val();})
-            .filter(function(el, idx, array) {return el <= maxbox.val();})
+        slider.slider('values',1,value);
+        jQuery("#highdimension-filter-subjectcount").html(omicsFilterValues.filter(function (el, idx, array) {return el >= minboxVal;})
+            .filter(function(el, idx, array) {return el <= value;})
             .length);
-        var min = slider.slider('option', 'min');
-        var max = slider.slider('option', 'max');
-        omicsSliderHighHandleRatio = (maxbox.val() - min) / (max - min);
+        omicsSliderHighHandleRatio = (value - sliderMin) / (sliderMax - sliderMin);
     });
 
     // let the enter key blur the text fields, thus updating the slider and subject counts
@@ -495,9 +511,25 @@ function applySingleNumericOmicsFilter(validation) {
         // filter
         if (validation) {
             if (params.selector == "") {
-                alert("You must choose a gene.");
+                // no gene supplied, we assume a "no value" type filter
+                omicsFilterValues = [];
+                omicsSliderLowHandleRatio = 0;
+                omicsSliderHighHandleRatio = 1;
+                document.getElementById("highdimension-filter-main").removeChild(document.getElementById("highdimension-filter-content"));
+                omicsfilterwin.hide();
+                var concept = jQuery('#' + selectedConcept.id);
+                jQuery('#' + selectedConcept.id + " .concept-text").html(selectedConcept.attributes["conceptname"].nodeValue);
+                concept.removeAttr("omicsproperty");
+                concept.removeAttr("omicsselector");
+                concept.removeAttr("omicsoperator");
+                concept.removeAttr("omicsvalue");
+                concept.removeAttr("omicsprojection");
+                concept.removeAttr("omicsvaluetype");
+                concept.attr("setvaluemode","");
+                moveSelectedConceptFromHoldingToTarget();
                 return;
             }
+
 
             var in_list = false;
             for (var i = 0; i < omicsAutoCompleteList.length; i++) {

--- a/web-app/js/datasetExplorer/querypanels.js
+++ b/web-app/js/datasetExplorer/querypanels.js
@@ -364,12 +364,16 @@ function getPanelItemFromConcept(concept) {
     // We try to infer the type when possible to match the icon
     jQuery.get(pageInfo.basePath + "/concepts/getResource", { concept_key: concept["conceptid"] }, function() {}, 'json')
         .success(function (data) {
-            jQuery("span:first", _item).addClass(getClassForNodeResource(data))
+            jQuery("span:first", _item).addClass(getClassForNodeResource(data));
+            jQuery.each(data.visualAttributes, function (index, value) {
+                if (value.toUpperCase() == "HIGH_DIMENSIONAL")
+                    _item.attr("oktousevalues", "H");
+            });
         })
 
     _item
         .append(jQuery("<span />").addClass("x-tree-node-icon"))
-        .append(jQuery("<span />").addClass("concept-text").html(concept.conceptname + _valueText))
+        .append(jQuery("<span />").addClass("concept-text").html(concept.conceptname + " " + _valueText))
 
     jQuery.each(concept, function(key, value) {
         _item.attr(key, value)


### PR DESCRIPTION
Hidome Feature: when search term left empty, you get a 'no-value' typ…e filter. I.e. match all subjects who have the high dimensional concept (a.k.a. the original pre-Hidome behavior)

Fix: when entering numeric values manually in the min and max boxes, they are no longer compared as strings.