### PR TITLE
Fixes for HiDome

### DIFF
--- a/grails-app/controllers/ChartController.groovy
+++ b/grails-app/controllers/ChartController.groovy
@@ -272,8 +272,6 @@ class ChartController {
         PrintWriter pw = new PrintWriter(response.getOutputStream());
 
         if (concept_key && !concept_key.isEmpty()) {
-
-
             // We retrieve the highdimension parameters from the client, if they were passed
             def omics_params = [:]
             params.findAll { k, v ->
@@ -281,7 +279,7 @@ class ChartController {
             }.each { k, v ->
                 omics_params[k] = v
             }
-            if (omics_params) {  // empty maps are coerced to false by groovy
+            if (omics_params) {
                 omics_params.concept_key = concept_key
                 if (s1) highDimensionQueryService.addHighDimConceptDataToTable(table, omics_params, result_instance_id1)
                 if (s2) highDimensionQueryService.addHighDimConceptDataToTable(table, omics_params, result_instance_id2)

--- a/grails-app/controllers/HighDimensionFilterController.groovy
+++ b/grails-app/controllers/HighDimensionFilterController.groovy
@@ -1,9 +1,7 @@
 import grails.converters.JSON
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.core.querytool.ConstraintByOmicsValue
 import org.transmartproject.db.dataquery.highdim.DeGplInfo
 import org.transmartproject.db.dataquery.highdim.DeSubjectSampleMapping
-
 /**
  * Author: Denny Verbeeck (dverbeec@its.jnj.com)
  */
@@ -43,14 +41,23 @@ class HighDimensionFilterController {
 
         def resource = highDimensionResourceService.getHighDimDataTypeResourceFromConcept(concept_key)
 
-        def model = [gpl_id: platform.id,
-                     marker_type: platform.markerType,
-                     filter_type: resource.getHighDimensionFilterType(),
-                     searchable_properties: resource.getSearchableAnnotationProperties().collectEntries {[it, searchableAnnotationPropertiesDictionary.get(it, it)]},
-                     filter: filter,
-                     projections: resource.getSearchableProjections().collectEntries {[it, Projection.prettyNames.get(it, it)]}]
+        if (resource.dataTypeName == 'vcf') {
+            render "Small Variant data is not supperted yet, stay tuned!"
+        }
+        else {
+            def model = [gpl_id               : platform.id,
+                         marker_type          : platform.markerType,
+                         filter_type          : resource.getHighDimensionFilterType(),
+                         searchable_properties: resource.getSearchableAnnotationProperties().collectEntries {
+                             [it, searchableAnnotationPropertiesDictionary.get(it, it)]
+                         },
+                         filter               : filter,
+                         projections          : resource.getSearchableProjections().collectEntries {
+                             [it, Projection.prettyNames.get(it, it)]
+                         }]
 
-        render(template: template, model: model)
+            render(template: template, model: model)
+        }
     }
 
     /**

--- a/grails-app/services/I2b2HelperService.groovy
+++ b/grails-app/services/I2b2HelperService.groovy
@@ -603,6 +603,15 @@ class I2b2HelperService {
         return res;
     }
 
+    /**
+     * Check if a map contains all the keys an omics_params map should contain
+     * @param params the map to check
+     * @return True if the map contains all necessary keys, false otherwise
+     */
+    def Boolean isValidOmicsParams(Map params) {
+        ['omics_selector', 'omics_projection_type', 'omics_property', 'omics_selector'].every {params?.containsKey(it)}
+    }
+
     def Boolean nodeXmlRepresentsValueConcept(String xml) {
         Boolean res = false;
 
@@ -636,11 +645,12 @@ class I2b2HelperService {
 
         def xTrialsCaseFlag = isXTrialsConcept(concept_key)
         def leafNodeFlag = isLeafConceptKey(concept_key)
+        def highDimNodeFlag = isHighDimensionalConceptKey(concept_key)
 
         def HashMap<String, Integer> results = new LinkedHashMap<String, Integer>()
 
         log.trace "input concept_key = " + concept_key
-        if (leafNodeFlag) {
+        if (leafNodeFlag && !highDimNodeFlag) {
             concept_key = getParentConceptKey(concept_key)
         }
         log.trace "lookup concept_key = " + concept_key
@@ -656,7 +666,7 @@ class I2b2HelperService {
 
         } else {
             String fullname = concept_key.substring(concept_key.indexOf("\\", 2), concept_key.length());
-            int i = getLevelFromKey(concept_key) + 1;
+            int i = getLevelFromKey(concept_key) + (highDimNodeFlag ? 0 : 1);
             Sql sql = new Sql(dataSource);
             String sqlt = """
                 SELECT DISTINCT c_name, c_fullname


### PR DESCRIPTION
Fix dialog behavior for VCF datatype: dragging into a panel leads to the 'No filter' behavior. Right-clicking and choosing Set filter shows the not supported yet message.
Fix concept count bar charts not showing up in summary statistics when using the 'No filter' dialog option.
Fix grid view columns for high dimensional nodes not appearing when using the 'No filter' dialog option
Fix uncaught exceptions when specifying constraints that lead to an empty patient set.
Fix bug related to using only Subset 2 with high dimensional data