### PR TITLE
Fixing "OAuth2ValidationException: Failed to save authorization code"

### DIFF
--- a/grails-app/domain/org/transmart/oauth2/AccessToken.groovy
+++ b/grails-app/domain/org/transmart/oauth2/AccessToken.groovy
@@ -26,7 +26,7 @@ class AccessToken {
         scope nullable: false
         refreshToken nullable: true
         authenticationKey nullable: false, blank: false, unique: true
-        authentication nullable: false, minSize: 1, maxSize: 1024 * 4
+        authentication nullable: false, minSize: 1, maxSize: 1024 * 32
         additionalInformation nullable: true
     }
 

--- a/grails-app/domain/org/transmart/oauth2/AuthorizationCode.groovy
+++ b/grails-app/domain/org/transmart/oauth2/AuthorizationCode.groovy
@@ -7,7 +7,7 @@ class AuthorizationCode {
 
     static constraints = {
         code nullable: false, blank: false, unique: true
-        authentication nullable: false, minSize: 1, maxSize: 1024 * 4
+        authentication nullable: false, minSize: 1, maxSize: 1024 * 16
     }
 
     static mapping = {

--- a/grails-app/domain/org/transmart/oauth2/AuthorizationCode.groovy
+++ b/grails-app/domain/org/transmart/oauth2/AuthorizationCode.groovy
@@ -7,7 +7,7 @@ class AuthorizationCode {
 
     static constraints = {
         code nullable: false, blank: false, unique: true
-        authentication nullable: false, minSize: 1, maxSize: 1024 * 16
+        authentication nullable: false, minSize: 1, maxSize: 1024 * 32
     }
 
     static mapping = {

--- a/grails-app/domain/org/transmart/oauth2/RefreshToken.groovy
+++ b/grails-app/domain/org/transmart/oauth2/RefreshToken.groovy
@@ -9,7 +9,7 @@ class RefreshToken {
     static constraints = {
         value nullable: false, blank: false, unique: true
         expiration nullable: true
-        authentication nullable: false, minSize: 1, maxSize: 1024 * 4
+        authentication nullable: false, minSize: 1, maxSize: 1024 * 32
     }
 
     static mapping = {


### PR DESCRIPTION
This happens when activating both Kerberos authentication and OAuth token system.

Here is the fullstack:
```
2017-10-24 14:25:59,641 [http-apr-8080-exec-8] ERROR StackTrace  - Full Stack Trace:
grails.plugin.springsecurity.oauthprovider.exceptions.OAuth2ValidationException: Failed to save authorization code:
- Field error in object 'org.transmart.oauth2.AuthorizationCode' on field 'authentication': rejected value [[B@8558e0b]; codes [org.transmart.oauth2.AuthorizationCode.authentication.maxSize.error.org.transmart.oauth2.AuthorizationCode.authentication,org.transmart.oauth2.AuthorizationCode.authentication.maxSize.error.authentication,org.transmart.oauth2.AuthorizationCode.authentication.maxSize.error.[B,org.transmart.oauth2.AuthorizationCode.authentication.maxSize.error,authorizationCode.authentication.maxSize.error.org.transmart.oauth2.AuthorizationCode.authentication,authorizationCode.authentication.maxSize.error.authentication,authorizationCode.authentication.maxSize.error.[B,authorizationCode.authentication.maxSize.error,org.transmart.oauth2.AuthorizationCode.authentication.maxSize.exceeded.org.transmart.oauth2.AuthorizationCode.authentication,org.transmart.oauth2.AuthorizationCode.authentication.maxSize.exceeded.authentication,org.transmart.oauth2.AuthorizationCode.authentication.maxSize.exceeded.[B,org.transmart.oauth2.AuthorizationCode.authentication.maxSize.exceeded,authorizationCode.authentication.maxSize.exceeded.org.transmart.oauth2.AuthorizationCode.authentication,authorizationCode.authentication.maxSize.exceeded.authentication,authorizationCode.authentication.maxSize.exceeded.[B,authorizationCode.authentication.maxSize.exceeded,maxSize.exceeded.org.transmart.oauth2.AuthorizationCode.authentication,maxSize.exceeded.authentication,maxSize.exceeded.[B,maxSize.exceeded]; arguments [authentication,class org.transmart.oauth2.AuthorizationCode,[B@8558e0b,4096]; default message [Property [{0}] of class [{1}] with value [{2}] exceeds the maximum size of [{3}]]

        at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
        at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.lang.reflect.Constructor.newInstance(Constructor.java:526)
        at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:77)
        at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:102)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:57)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:182)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:194)
        at grails.plugin.springsecurity.oauthprovider.GormAuthorizationCodeService.store(GormAuthorizationCodeService.groovy:27)
        at org.springframework.security.oauth2.provider.code.RandomValueAuthorizationCodeServices.createAuthorizationCode(RandomValueAuthorizationCodeServices.java:23)
        at org.springframework.security.oauth2.provider.code.RandomValueAuthorizationCodeServices$$FastClassBySpringCGLIB$$de6f5066.invoke(<generated>)
        at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:204)
        at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:700)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:150)
        at org.springframework.transaction.interceptor.TransactionInterceptor$1.proceedWithInvocation(TransactionInterceptor.java:96)
        at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:260)
        at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:94)
        at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:172)
        at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:633)
        at grails.plugin.springsecurity.oauthprovider.GormAuthorizationCodeService$$EnhancerBySpringCGLIB$$d67d6630.createAuthorizationCode(<generated>)
        at org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint.generateCode(AuthorizationEndpoint.java:334)
        at org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint.getAuthorizationCodeResponse(AuthorizationEndpoint.java:282)
        at org.springframework.security.oauth2.provider.endpoint.AuthorizationEndpoint.approveOrDeny(AuthorizationEndpoint.java:233)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.springframework.web.method.support.InvocableHandlerMethod.invoke(InvocableHandlerMethod.java:215)
        at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:132)
        at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:104)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandleMethod(RequestMappingHandlerAdapter.java:745)
        at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:685)
        at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:80)
        at org.codehaus.groovy.grails.web.servlet.GrailsDispatcherServlet.doDispatch(GrailsDispatcherServlet.java:355)
        at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:851)
        at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:953)
        at org.springframework.web.servlet.FrameworkServlet.doPost(FrameworkServlet.java:855)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:650)
```