### PR TITLE
Remove the em tag so that the user can click on the number an…

### DIFF
--- a/web-app/js/datasetExplorer/ext-i2b2.js
+++ b/web-app/js/datasetExplorer/ext-i2b2.js
@@ -176,7 +176,7 @@ function getChildConceptPatientCountsComplete(result, node) {
         var access = childaccess != null ? childaccess[fullname] : undefined;
         var child = children[i];
         if (count != undefined) {
-            child.setText(child.text + "<em> (" + count + ")</em>");
+            child.setText(child.text + " (" + count + ")");
         }
 
         if ((access != undefined && access != 'Locked') ||


### PR DESCRIPTION
The user was unable to click on the number in the tree and drag the term into the interface.  This is because EXT doesn't seem to like tags inside the nodes.  This reverts the look of the tree back to 16.1 (no longer gray).