### PR TITLE
Sort Pie chart legend by category

### DIFF
--- a/grails-app/services/I2b2HelperService.groovy
+++ b/grails-app/services/I2b2HelperService.groovy
@@ -1555,6 +1555,7 @@ class I2b2HelperService {
                 ON ps.patient_num=pd.patient_num AND result_instance_id = ?
         ) base
         GROUP BY cat
+        ORDER BY cat
         """;
 
 //      String sqlt = """SELECT a.cat as demcategory, COALESCE(b.demcount,0) as demcount FROM


### PR DESCRIPTION
16.2 seems to have lost the sorting in the legend of the pie chart on the summary tab.  This sorts the items in the table by Category.