### PR TITLE
Allow user to click off the utilities menu to close it

### DIFF
--- a/grails-app/views/layouts/_utilitiesMenu.gsp
+++ b/grails-app/views/layouts/_utilitiesMenu.gsp
@@ -5,7 +5,7 @@
     }
 
     jQuery(document).ready(function () {
-        jQuery('#main').click(function () {
+	jQuery('body').on('click', '#centerMainPanel', function() {
             jQuery('#utilitiesMenu').hide();
         });
     });


### PR DESCRIPTION
Currently, if the user clicks off the utilities menu, it does not close.  This fix allows the user to click anywhere else on the screen and the utilities menu will close.