### PR TITLE
Allow user to disable grid-view and still have application work 

### DIFF
--- a/web-app/js/datasetExplorer/i2b2common.js
+++ b/web-app/js/datasetExplorer/i2b2common.js
@@ -433,6 +433,32 @@ function applySetValueDialog(validation) {
 	}
 }
 
+
+function setValueMethodChanged(value)
+{
+	if(value=="highlow") {
+		document.getElementById("divhighlow").style.display="inline";
+	    document.getElementById("divnumeric").style.display="none";
+	}
+	if(value=="numeric") {
+	    document.getElementById("divhighlow").style.display="none";
+	    document.getElementById("divnumeric").style.display="inline"; 
+	}
+	if(value=="novalue") {
+		document.getElementById("divhighlow").style.display="none";
+		document.getElementById("divnumeric").style.display="none";
+	}
+}
+
+function setValueOperatorChanged(value) {
+	if(value=="BETWEEN") {
+		document.getElementById("divhighvalue").style.display="inline";
+	}
+	else {
+		document.getElementById("divhighvalue").style.display="none"; 
+	}
+}
+
 function showSetValueDialog()
 {
 	var conceptnode=selectedConcept; //not dragging so selected concept is what im updating
@@ -541,7 +567,9 @@ function clearAnalysisPanel()
 	var cleartxt2="<div style='text-align:center;font:12pt arial;width:100%;height:100%;'><table style='width:100%;height:100%;'><tr><td align='center' valign='center'>Select Advanced->Haploview from the menu</td></tr></table></div>";
 	updateAnalysisPanel(cleartxt, false);
 	var ag=Ext.getCmp("analysisGridPanel");
-	ag.body.update("<div></div>");
+	if (typeof(ag.body) !== "undefined") {
+		ag.body.update("<div></div>");
+	}
 	var aog=Ext.getCmp("analysisOtherPanel");
 	if(aog) aog.body.update(cleartxt2);
 	clearGrid();

--- a/web-app/panels/setValueDialog.html
+++ b/web-app/panels/setValueDialog.html
@@ -8,32 +8,6 @@
   </head>
   
   <body>
-    <script type="text/javascript">
-  function setValueMethodChanged(value)
-  {
-  if(value=="highlow")
-      {document.getElementById("divhighlow").style.display="inline";
-       document.getElementById("divnumeric").style.display="none";
-       }
-  if(value=="numeric")
-      {
-      document.getElementById("divhighlow").style.display="none";
-      document.getElementById("divnumeric").style.display="inline"; 
-      }
-  if(value=="novalue")
-  	{
-  	 document.getElementById("divhighlow").style.display="none";
-     document.getElementById("divnumeric").style.display="none";
-  	}
-  }
-  function setValueOperatorChanged(value)
-  {
-  if(value=="BETWEEN")
-  document.getElementById("divhighvalue").style.display="inline";
-  else
-  document.getElementById("divhighvalue").style.display="none"; 
-  }
-    </script>
   <div style="background:#eee;height:100%;padding:5px;">
 
   <table style="font:9pt arial;width=500px">


### PR DESCRIPTION
We disabled gridview in our version of transmart, and were unable to clear a subset.  This is because the javascript encountered an error when trying to get the body of the gridview component (which did not exist), and could not continue.

This adds a quick check to make sure we were able to grab the body before trying to update.  

We also threw in a little code cleanup, in terms of moving the javascript out of the html.