### PR TITLE
Page title reset after Genome Browser

### DIFF
--- a/web-app/js/datasetExplorer/datasetExplorer.js
+++ b/web-app/js/datasetExplorer/datasetExplorer.js
@@ -717,6 +717,9 @@ Ext.onReady(function () {
     /* load the legacy hardcoded tabs */
     loadPlugin('dalliance-plugin', '/Dalliance/loadScripts', function () {
         loadDalliance(resultsTabPanel);
+        Ext.getCmp('dallianceBrowser').on('deactivate', function() {
+            document.title = 'Dataset Explorer';
+        });
     }, true);
 
     if (GLOBAL.metacoreAnalyticsEnabled === 'true') {


### PR DESCRIPTION
When a user navigates to the genome browser, it changes the page title, but it does not get changed back when the user navigates away.  This will change the page title back to the default "Dataset Explorer" page title.