### PR TITLE
Fixes duplicated summary charts

### DIFF
--- a/grails-app/services/ChartService.groovy
+++ b/grails-app/services/ChartService.groovy
@@ -145,7 +145,9 @@ class ChartService {
         }.each {
             def key = it.concept_key + it.omics_selector + " - " + it.omics_projection_type
             if (!concepts.containsKey(key))
-              concepts[key] = getConceptAnalysis(concept: it.concept_key, subsets: subsets, omics_params: it)
+		if (i2b2HelperService.isHighDimensionalConceptKey(it.concept_key)) {
+              		concepts[key] = getConceptAnalysis(concept: it.concept_key, subsets: subsets, omics_params: it)
+		}
         }
         concepts
     }


### PR DESCRIPTION
The code was duplicating charts on the summary tab when the user selects something on the comparison tab.  The race, sex and age charts were fine, but below that the concept analysis itself was duplicated.  This was because we were missing a check when generating the high dimensional charts to make sure it was actually a high dimensional concept.  We had the reciprocal check.